### PR TITLE
Implemention of more methods to make biscuit-php usable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
-use ext_php_rs::binary_slice::BinarySlice;
 use ext_php_rs::builders::ClassBuilder;
 use ext_php_rs::zend::{ce, ClassEntry, ModuleEntry};
 use ext_php_rs::{info_table_end, info_table_row, info_table_start, prelude::*};
+use std::collections::HashMap;
 
 #[derive(Debug, ZvalConvert)]
 pub enum MixedValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@ impl KeyPair {
         Self(biscuit_auth::KeyPair::new())
     }
 
-    pub fn from_private_key(private_key: BinarySlice<u8>) -> PhpResult<Self> {
+    pub fn from_private_key(private_key: &str) -> PhpResult<Self> {
         let pk = PrivateKey::__construct(private_key)?;
         Ok(Self(biscuit_auth::KeyPair::from(&pk.0)))
     }
@@ -476,8 +476,8 @@ pub struct PublicKey(biscuit_auth::PublicKey);
 
 #[php_impl]
 impl PublicKey {
-    pub fn __construct(key: BinarySlice<u8>) -> PhpResult<Self> {
-        let key = biscuit_auth::PublicKey::from_bytes(key.into()).map_err(|e| {
+    pub fn __construct(key: &str) -> PhpResult<Self> {
+        let key = biscuit_auth::PublicKey::from_bytes_hex(key).map_err(|e| {
             PhpException::new(e.to_string(), 0, unsafe {
                 INVALID_PUBLIC_KEY.expect("did not set exception ce")
             })
@@ -487,7 +487,7 @@ impl PublicKey {
     }
 
     pub fn to_hex(&self) -> String {
-        hex::encode(self.0.to_bytes())
+        self.0.to_bytes_hex()
     }
 }
 
@@ -497,8 +497,8 @@ pub struct PrivateKey(biscuit_auth::PrivateKey);
 
 #[php_impl]
 impl PrivateKey {
-    pub fn __construct(key: BinarySlice<u8>) -> PhpResult<Self> {
-        let key = biscuit_auth::PrivateKey::from_bytes(key.into()).map_err(|e| {
+    pub fn __construct(key: &str) -> PhpResult<Self> {
+        let key = biscuit_auth::PrivateKey::from_bytes_hex(key).map_err(|e| {
             PhpException::new(e.to_string(), 0, unsafe {
                 INVALID_PRIVATE_KEY.expect("did not set exception ce")
             })
@@ -508,7 +508,7 @@ impl PrivateKey {
     }
 
     pub fn to_hex(&self) -> String {
-        hex::encode(self.0.to_bytes())
+        self.0.to_bytes_hex()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,18 @@ pub enum MixedValue {
     None,
 }
 
+impl From<biscuit_auth::builder::Fact> for MixedValue {
+    fn from(value: biscuit_auth::builder::Fact) -> Self {
+        let vec: Vec<String> = value
+            .predicate
+            .terms
+            .iter()
+            .map(|x| x.to_string())
+            .collect();
+        MixedValue::ParsedStr(vec.join("|"))
+    }
+}
+
 #[php_class(name = "Biscuit\\Auth\\Biscuit")]
 pub struct Biscuit(biscuit_auth::Biscuit);
 
@@ -117,6 +129,14 @@ impl Authorizer {
 
     pub fn __to_string(&mut self) -> String {
         format!("{}", self)
+    }
+
+    pub fn query(&mut self, rule: &str) -> PhpResult<Vec<MixedValue>> {
+        self.0.query(rule).map_err(|e| {
+            PhpException::new(e.to_string(), 0, unsafe {
+                AUTHORIZER_ERROR.expect("did not set exception ce")
+            })
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,28 @@ impl Biscuit {
                 .map_err(|e| format!("Biscuit error: {}", e))?,
         ))
     }
+
+    pub fn from_base64(biscuit: &str, public_key: &PublicKey) -> PhpResult<Self> {
+        Ok(Self(
+            biscuit_auth::Biscuit::from_base64(biscuit, public_key.0)
+                .map_err(|e| format!("Biscuit error: {}", e))?,
+        ))
+    }
+
+    pub fn to_base64(&mut self) -> PhpResult<String> {
+        Ok(self
+            .0
+            .to_base64()
+            .map_err(|e| format!("Biscuit error: {}", e))?)
+    }
+
+    pub fn authorizer(&mut self) -> PhpResult<Authorizer> {
+        Ok(Authorizer(
+            self.0
+                .authorizer()
+                .map_err(|e| format!("Biscuit error: {}", e))?,
+        ))
+    }
 }
 
 #[php_class(name = "Biscuit\\Auth\\Authorizer")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,18 @@ impl BiscuitBuilder {
                 })
             })
     }
+
+    pub fn build(&mut self, root_key: &KeyPair) -> PhpResult<Biscuit> {
+        self.0
+            .clone()
+            .build(&root_key.0)
+            .and_then(|b| Ok(Biscuit(b)))
+            .map_err(|e| {
+                PhpException::new(e.to_string(), 0, unsafe {
+                    INVALID_TERM.expect("did not set exception ce")
+                })
+            })
+    }
 }
 
 #[php_class(name = "Biscuit\\Auth\\BlockBuilder")]

--- a/stubs/Biscuit/Auth/Authorizer.php
+++ b/stubs/Biscuit/Auth/Authorizer.php
@@ -4,9 +4,9 @@
  */
 namespace Biscuit\Auth;
 
-class Authorizer
+class Authorizer implements \Stringable
 {
-    public function addToken(\Biscuit\Auth\Biscuit $token)
+    public function addToken(\Biscuit\Auth\Biscuit $token) : void
     {
     }
 
@@ -31,6 +31,14 @@ class Authorizer
     }
 
     public function authorize() : int
+    {
+    }
+
+    public function __toString() : string
+    {
+    }
+
+    public function query(string $rule) : array
     {
     }
 

--- a/stubs/Biscuit/Auth/Biscuit.php
+++ b/stubs/Biscuit/Auth/Biscuit.php
@@ -6,6 +6,18 @@ namespace Biscuit\Auth;
 
 class Biscuit
 {
+    public static function fromBase64(string $biscuit, \Biscuit\Auth\PublicKey $public_key) : \Biscuit\Auth\Biscuit
+    {
+    }
+
+    public function toBase64() : string
+    {
+    }
+
+    public function authorizer() : \Biscuit\Auth\Authorizer
+    {
+    }
+
     public function __construct(\Biscuit\Auth\PrivateKey $root_key)
     {
     }

--- a/stubs/Biscuit/Auth/BiscuitBuilder.php
+++ b/stubs/Biscuit/Auth/BiscuitBuilder.php
@@ -30,6 +30,10 @@ class BiscuitBuilder
     {
     }
 
+    public function build(\Biscuit\Auth\KeyPair $root_key) : \Biscuit\Auth\Biscuit
+    {
+    }
+
     public function __construct()
     {
     }


### PR DESCRIPTION
I have implemented some more methods to make this php binding usable:

- Added methods `from_base64` and `to_base64` into `Biscuit` class for allowing some de/serializations
- Added method `authorizer` into `Biscuit` class to get an `Authorizer` object in order to test our rules on the biscuit
- Added method `build` into `BiscuitBuilder` to get a `Biscuit` from a `BiscuitBuilder`
- Changed constructors, `from_...` and `to_hex` methods in `KeyPair`, `PublicKey` and `PrivateKey` classes to handle strings instead of bytes since in my tests I was unable to load a private key from a string
- Added method `query` into `Authorizer` class. It's more an hack than a functional thing but I don't have the time to do it properly: instead of returning a list, it returns a string like this: `"term1"|"term2"|3`