### PR TITLE
feat(pie): add support for pre-built-binaries + more OS-Arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,21 +60,22 @@ jobs:
         run: |
           cargo build --release --target x86_64-unknown-linux-gnu
 
-      - name: Prepare binary artifact
+      - name: Package PIE binary
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
+          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-x86_64-linux-glibc-${TSMODE}.zip"
           mkdir -p dist
-          cp target/x86_64-unknown-linux-gnu/release/libbiscuit.so dist/biscuit-linux-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}.so
-
-      - name: Calculate checksums
-        run: |
+          cp target/x86_64-unknown-linux-gnu/release/libbiscuit.so dist/biscuit.so
           cd dist
-          sha256sum biscuit-linux-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}.so > biscuit-linux-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}.so.sha256
+          zip "${ARCHIVE_NAME}" biscuit.so
+          rm biscuit.so
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: binary-linux-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}
-          path: dist/*
+          name: pie-linux-x86_64-glibc-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist/*.zip
 
   build-linux-x86_64-musl:
     name: Build Linux x86_64 musl - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
@@ -105,7 +106,8 @@ jobs:
             clang-dev \
             llvm \
             llvm-dev \
-            musl-dev
+            musl-dev \
+            zip
 
       - name: Set LIBCLANG_PATH
         run: |
@@ -121,26 +123,26 @@ jobs:
           source $HOME/.cargo/env
           cargo build --release
 
-      - name: Prepare binary artifact
+      - name: Package PIE binary
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
+          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-x86_64-linux-musl-${TSMODE}.zip"
           mkdir -p dist
-          cp target/release/libbiscuit.so dist/biscuit-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}.so
-
-      - name: Calculate checksums
-        run: |
+          cp target/release/libbiscuit.so dist/biscuit.so
           cd dist
-          sha256sum biscuit-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}.so > biscuit-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}.so.sha256
+          zip "${ARCHIVE_NAME}" biscuit.so
+          rm biscuit.so
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: binary-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}
-          path: dist/*
+          name: pie-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist/*.zip
 
-  verify-binaries:
-    name: Verify binaries
-    runs-on: ubuntu-latest
-    needs: build-linux-x86_64
+  build-linux-arm64:
+    name: Build Linux arm64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
@@ -149,6 +151,239 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-cargo-
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          ini-values: memory_limit=-1
+          extensions: mbstring
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Build release binary
+        run: |
+          cargo build --release --target aarch64-unknown-linux-gnu
+
+      - name: Package PIE binary
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
+          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-arm64-linux-glibc-${TSMODE}.zip"
+          mkdir -p dist
+          cp target/aarch64-unknown-linux-gnu/release/libbiscuit.so dist/biscuit.so
+          cd dist
+          zip "${ARCHIVE_NAME}" biscuit.so
+          rm biscuit.so
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: pie-linux-arm64-glibc-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist/*.zip
+
+  build-linux-arm64-musl:
+    name: Build Linux arm64 musl - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: php:${{ matrix.php-version }}-${{ matrix.phpts == 'ts' && 'zts' || 'cli' }}-alpine
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+    env:
+      RUSTFLAGS: "-C target-feature=-crt-static -C linker=gcc"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache \
+            curl \
+            bash \
+            build-base \
+            openssl-dev \
+            pkgconfig \
+            git \
+            clang \
+            clang-libs \
+            clang-dev \
+            llvm \
+            llvm-dev \
+            musl-dev \
+            zip
+
+      - name: Set LIBCLANG_PATH
+        run: |
+          echo "LIBCLANG_PATH=/usr/lib" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Build release binary
+        run: |
+          source $HOME/.cargo/env
+          cargo build --release
+
+      - name: Package PIE binary
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
+          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-arm64-linux-musl-${TSMODE}.zip"
+          mkdir -p dist
+          cp target/release/libbiscuit.so dist/biscuit.so
+          cd dist
+          zip "${ARCHIVE_NAME}" biscuit.so
+          rm biscuit.so
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: pie-linux-arm64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist/*.zip
+
+  build-macos-x86_64:
+    name: Build macOS x86_64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: macos-15-intel
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: macos-x86_64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            macos-x86_64-cargo-
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          ini-values: memory_limit=-1
+          extensions: mbstring
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Build release binary
+        run: |
+          cargo build --release --target x86_64-apple-darwin
+
+      - name: Package PIE binary
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
+          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-x86_64-darwin-bsdlibc-${TSMODE}.zip"
+          mkdir -p dist
+          cp target/x86_64-apple-darwin/release/libbiscuit.dylib dist/biscuit.so
+          cd dist
+          zip "${ARCHIVE_NAME}" biscuit.so
+          rm biscuit.so
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: pie-macos-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist/*.zip
+
+  build-macos-arm64:
+    name: Build macOS arm64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: macos-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            macos-arm64-cargo-
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          ini-values: memory_limit=-1
+          extensions: mbstring
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Build release binary
+        run: |
+          cargo build --release --target aarch64-apple-darwin
+
+      - name: Package PIE binary
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
+          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-arm64-darwin-bsdlibc-${TSMODE}.zip"
+          mkdir -p dist
+          cp target/aarch64-apple-darwin/release/libbiscuit.dylib dist/biscuit.so
+          cd dist
+          zip "${ARCHIVE_NAME}" biscuit.so
+          rm biscuit.so
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: pie-macos-arm64-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist/*.zip
+
+  verify-linux-x86_64:
+    name: Verify Linux x86_64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: ubuntu-latest
+    needs: build-linux-x86_64
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+
+    steps:
       - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
         uses: shivammathur/setup-php@v2
         with:
@@ -160,20 +395,17 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v7
         with:
-          name: binary-linux-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          name: pie-linux-x86_64-glibc-php${{ matrix.php-version }}-${{ matrix.phpts }}
           path: dist
 
-      - name: Verify checksum
+      - name: Verify binary
         run: |
           cd dist
-          sha256sum -c biscuit-linux-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}.so.sha256
+          unzip *.zip
+          php -dextension=./biscuit.so -m | grep biscuit
 
-      - name: Test binary loading
-        run: |
-          php -dextension=./dist/biscuit-linux-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}.so -m | grep biscuit || echo "Extension loaded successfully"
-
-  verify-binaries-musl:
-    name: Verify musl binaries
+  verify-linux-x86_64-musl:
+    name: Verify Linux x86_64 musl - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
     runs-on: ubuntu-latest
     container:
       image: php:${{ matrix.php-version }}-${{ matrix.phpts == 'ts' && 'zts' || 'cli' }}-alpine
@@ -184,27 +416,148 @@ jobs:
         phpts: ["ts", "nts"]
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Install unzip
+        run: apk add --no-cache unzip
 
       - name: Download artifact
         uses: actions/download-artifact@v7
         with:
-          name: binary-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          name: pie-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}
           path: dist
 
-      - name: Verify checksum
+      - name: Verify binary
         run: |
           cd dist
-          sha256sum -c biscuit-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}.so.sha256
+          unzip *.zip
+          php -dextension=./biscuit.so -m | grep biscuit
 
-      - name: Test binary loading
+  verify-linux-arm64:
+    name: Verify Linux arm64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: ubuntu-24.04-arm
+    needs: build-linux-arm64
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+
+    steps:
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pie-linux-arm64-glibc-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist
+
+      - name: Verify binary
         run: |
-          php -dextension=./dist/biscuit-linux-x86_64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}.so -m | grep biscuit || echo "Extension loaded successfully"
+          cd dist
+          unzip *.zip
+          php -dextension=./biscuit.so -m | grep biscuit
+
+  verify-linux-arm64-musl:
+    name: Verify Linux arm64 musl - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: ubuntu-24.04-arm
+    container:
+      image: php:${{ matrix.php-version }}-${{ matrix.phpts == 'ts' && 'zts' || 'cli' }}-alpine
+    needs: build-linux-arm64-musl
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+
+    steps:
+      - name: Install unzip
+        run: apk add --no-cache unzip
+
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pie-linux-arm64-musl-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist
+
+      - name: Verify binary
+        run: |
+          cd dist
+          unzip *.zip
+          php -dextension=./biscuit.so -m | grep biscuit
+
+  verify-macos-x86_64:
+    name: Verify macOS x86_64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: macos-15-intel
+    needs: build-macos-x86_64
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+
+    steps:
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pie-macos-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist
+
+      - name: Verify binary
+        run: |
+          cd dist
+          unzip *.zip
+          php -dextension=./biscuit.so -m | grep biscuit
+
+  verify-macos-arm64:
+    name: Verify macOS arm64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: macos-latest
+    needs: build-macos-arm64
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+
+    steps:
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pie-macos-arm64-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist
+
+      - name: Verify binary
+        run: |
+          cd dist
+          unzip *.zip
+          php -dextension=./biscuit.so -m | grep biscuit
 
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [verify-binaries, verify-binaries-musl]
+    needs:
+      - verify-linux-x86_64
+      - verify-linux-x86_64-musl
+      - verify-linux-arm64
+      - verify-linux-arm64-musl
+      - verify-macos-x86_64
+      - verify-macos-arm64
 
     steps:
       - uses: actions/checkout@v6
@@ -219,101 +572,13 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p release
-          find artifacts -name "*.so" -exec cp {} release/ \;
-          find artifacts -name "*.sha256" -exec cp {} release/ \;
-
-      - name: Generate release notes
-        id: release_notes
-        run: |
-          cat > release_notes.md << 'EOF'
-          ## Pre-built Binaries
-
-          This release includes pre-built binaries for Linux x86_64 (glibc and musl) across multiple PHP versions, with both Thread-Safe (TS) and Non-Thread-Safe (NTS) variants.
-
-          ### Available Binaries
-
-          #### Linux x86_64 (glibc)
-
-          | PHP Version | Thread Safety | Binary | Checksum |
-          |-------------|---------------|--------|----------|
-          | 8.1 | TS | biscuit-linux-x86_64-php8.1-ts.so | .sha256 |
-          | 8.1 | NTS | biscuit-linux-x86_64-php8.1-nts.so | .sha256 |
-          | 8.2 | TS | biscuit-linux-x86_64-php8.2-ts.so | .sha256 |
-          | 8.2 | NTS | biscuit-linux-x86_64-php8.2-nts.so | .sha256 |
-          | 8.3 | TS | biscuit-linux-x86_64-php8.3-ts.so | .sha256 |
-          | 8.3 | NTS | biscuit-linux-x86_64-php8.3-nts.so | .sha256 |
-          | 8.4 | TS | biscuit-linux-x86_64-php8.4-ts.so | .sha256 |
-          | 8.4 | NTS | biscuit-linux-x86_64-php8.4-nts.so | .sha256 |
-          | 8.5 | TS | biscuit-linux-x86_64-php8.5-ts.so | .sha256 |
-          | 8.5 | NTS | biscuit-linux-x86_64-php8.5-nts.so | .sha256 |
-
-          #### Linux x86_64 musl (Alpine Linux)
-
-          | PHP Version | Thread Safety | Binary | Checksum |
-          |-------------|---------------|--------|----------|
-          | 8.1 | TS | biscuit-linux-x86_64-musl-php8.1-ts.so | .sha256 |
-          | 8.1 | NTS | biscuit-linux-x86_64-musl-php8.1-nts.so | .sha256 |
-          | 8.2 | TS | biscuit-linux-x86_64-musl-php8.2-ts.so | .sha256 |
-          | 8.2 | NTS | biscuit-linux-x86_64-musl-php8.2-nts.so | .sha256 |
-          | 8.3 | TS | biscuit-linux-x86_64-musl-php8.3-ts.so | .sha256 |
-          | 8.3 | NTS | biscuit-linux-x86_64-musl-php8.3-nts.so | .sha256 |
-          | 8.4 | TS | biscuit-linux-x86_64-musl-php8.4-ts.so | .sha256 |
-          | 8.4 | NTS | biscuit-linux-x86_64-musl-php8.4-nts.so | .sha256 |
-          | 8.5 | TS | biscuit-linux-x86_64-musl-php8.5-ts.so | .sha256 |
-          | 8.5 | NTS | biscuit-linux-x86_64-musl-php8.5-nts.so | .sha256 |
-
-          ### Choosing the Right Binary
-
-          **glibc vs musl**:
-          - **glibc**: Use for standard Linux distributions (Ubuntu, Debian, Fedora, CentOS, etc.)
-          - **musl**: Use for Alpine Linux or other musl-based distributions
-
-          **Thread-Safe (TS)**: Use with Apache with mod_php, IIS, FrankenPHP, or other multi-threaded web servers
-          **Non-Thread-Safe (NTS)**: Use with PHP-FPM, CLI, or FastCGI deployments
-
-          To check your PHP thread safety:
-          ```bash
-          php -i | grep "Thread Safety"
-          ```
-
-          To check if you're using musl or glibc:
-          ```bash
-          ldd --version 2>&1 | head -1
-          ```
-
-          ### Installation
-
-          1. Determine your libc (glibc or musl) and PHP thread safety (see above)
-          2. Download the appropriate binary for your platform, PHP version, and thread safety
-          3. Verify the checksum:
-             ```bash
-             sha256sum -c biscuit-linux-x86_64[-musl]-php8.x-{ts|nts}.so.sha256
-             ```
-          4. Move the binary to your PHP extension directory
-          5. Add to your php.ini:
-             ```ini
-             extension=biscuit-linux-x86_64[-musl]-php8.x-{ts|nts}.so
-             ```
-          6. Verify installation:
-             ```bash
-             php -m | grep biscuit
-             ```
-
-          ### Building from Source
-
-          If pre-built binaries are not available for your platform, you can build from source:
-          ```bash
-          cargo build --release
-          ```
-
-          EOF
+          find artifacts -name "*.zip" -exec cp {} release/ \;
 
       - name: Create Release
         if: ${{ !inputs.dry_run }}
         uses: softprops/action-gh-release@v2
         with:
           files: release/*
-          body_path: release_notes.md
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           generate_release_notes: true
@@ -323,6 +588,6 @@ jobs:
       - name: Dry run summary
         if: ${{ inputs.dry_run }}
         run: |
-          echo "🧪 Dry run completed successfully!"
-          echo "📦 Artifacts that would be released:"
+          echo "Dry run completed successfully!"
+          echo "Artifacts that would be released:"
           ls -la release/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
           coverage: "none"
           ini-values: "memory_limit=-1"
           extensions: mbstring
+          tools: composer:v2.9.5
 
       - name: Build
         run: cargo build --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,26 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "biscuit-auth"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,17 +252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,9 +265,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -596,17 +565,18 @@ dependencies = [
 
 [[package]]
 name = "ext-php-rs"
-version = "0.15.4"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c719e3bb9dbffdac2b5db25bc5f5a9cbb237033dc5b2861f84b3e11e0cf297e3"
+checksum = "6c6ce0f549b84992322e48039adf0c483276f81993e401523ad12bd310b609ff"
 dependencies = [
  "anyhow",
- "bindgen",
  "bitflags",
  "cc",
  "cfg-if",
+ "ext-php-rs-bindgen",
  "ext-php-rs-build",
  "ext-php-rs-derive",
+ "inventory",
  "native-tls",
  "once_cell",
  "parking_lot",
@@ -616,19 +586,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "ext-php-rs-build"
-version = "0.1.0"
+name = "ext-php-rs-bindgen"
+version = "0.72.1-extphprs.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caec1c4b5c5b46d49c1831bc0567012f1189222755c074f58292829c670c6520"
+checksum = "4795dd0976bd7d7d321c49e88e836f8e5b5b2b481e089067e303f2945617458a"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "ext-php-rs-clang-sys",
+ "itertools 0.14.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "ext-php-rs-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561bce8a6312a6182c078cd987d8d9cb6bf9292a35817cfd009ea0bffa794f5f"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
-name = "ext-php-rs-derive"
-version = "0.11.7"
+name = "ext-php-rs-clang-sys"
+version = "1.8.1-extphprs.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392cae7cdb924b08b91ba28b35e2d72012e6f54fc11a8d4abc0cf37dc6255978"
+checksum = "aa1ad6e482017d457d57d73691f8bed148a8a6198babe90830310c3308480a61"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "ext-php-rs-derive"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d95ccaa852836477c0401b986e906d3a31810d9963ff7d6fde410d5bbaaa71"
 dependencies = [
  "convert_case",
  "darling",
@@ -813,19 +814,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
+name = "inventory"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
- "either",
+ "rustversion",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1367,6 +1368,12 @@ checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "PHP wrapper for Biscuit authorization tokens"
 authors = ["Pierre Tondereau <pierre.tondereau@protonmail.com>"]
 
 [dependencies]
-ext-php-rs = "0.15.4"
+ext-php-rs = "0.15.6"
 biscuit-auth = { version = "6.0.0", features = ["pem"] }
 hex = "0.4"
 

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "extension-name": "biscuit",
         "support-zts": true,
         "support-nts": true,
+        "download-url-method": ["pre-packaged-binary", "composer-default"],
         "configure-options": [
             {
                 "name": "debug",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -843,12 +843,12 @@ impl KeyPair {
         Self(BiscuitKeyPair::from(&private_key.0))
     }
 
-    #[php(getter)]
+    #[php(name = "getPublicKey")]
     pub fn get_public_key(&self) -> PublicKey {
         PublicKey(self.0.public())
     }
 
-    #[php(getter)]
+    #[php(name = "getPrivateKey")]
     pub fn get_private_key(&self) -> PrivateKey {
         PrivateKey(self.0.private())
     }


### PR DESCRIPTION
- Add PIE pre-built binary support to composer.json
- Rewrite release workflow to produce PIE-compatible ZIP archives
- Add macOS (x86_64 + arm64) and Linux arm64 (glibc + musl) builds
- Add verification jobs for all 6 platform combinations
- Enable pie install ptondereau/biscuit-php without requiring Rust toolchain 