### PR TITLE
feat: add Windows x86_64 builds for PIE 1.4 pre-packaged binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,70 @@ jobs:
           name: pie-macos-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}
           path: dist/*.zip
 
+  build-windows:
+    name: Build Windows x86_64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+        include:
+          - { php-version: "8.1", compiler: "vs16" }
+          - { php-version: "8.2", compiler: "vs16" }
+          - { php-version: "8.3", compiler: "vs16" }
+          - { php-version: "8.4", compiler: "vs17" }
+          - { php-version: "8.5", compiler: "vs17" }
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: windows-x86_64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            windows-x86_64-cargo-
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-pc-windows-msvc
+          components: rustfmt
+
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          ini-values: memory_limit=-1
+          extensions: mbstring
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Build release binary
+        run: cargo build --release --target x86_64-pc-windows-msvc
+
+      - name: Package PIE binary
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE="${{ matrix.phpts }}"
+          BASE_NAME="php_biscuit-${VERSION}-${{ matrix.php-version }}-${TSMODE}-${{ matrix.compiler }}-x86_64"
+          mkdir -p dist
+          cp target/x86_64-pc-windows-msvc/release/biscuit.dll dist/${BASE_NAME}.dll
+          cd dist
+          7z a "${BASE_NAME}.zip" "${BASE_NAME}.dll"
+          rm "${BASE_NAME}.dll"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: pie-windows-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist/*.zip
+
   build-macos-arm64:
     name: Build macOS arm64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
     runs-on: macos-latest
@@ -531,6 +595,46 @@ jobs:
           unzip *.zip
           php -dextension=./biscuit.so -m | grep biscuit
 
+  verify-windows:
+    name: Verify Windows x86_64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+    runs-on: windows-latest
+    needs: build-windows
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+        phpts: ["ts", "nts"]
+        include:
+          - { php-version: "8.1", compiler: "vs16" }
+          - { php-version: "8.2", compiler: "vs16" }
+          - { php-version: "8.3", compiler: "vs16" }
+          - { php-version: "8.4", compiler: "vs17" }
+          - { php-version: "8.5", compiler: "vs17" }
+
+    steps:
+      - name: Install PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+        env:
+          phpts: ${{ matrix.phpts }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: pie-windows-x86_64-php${{ matrix.php-version }}-${{ matrix.phpts }}
+          path: dist
+
+      - name: Verify binary
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TSMODE="${{ matrix.phpts }}"
+          DLL_NAME="php_biscuit-${VERSION}-${{ matrix.php-version }}-${TSMODE}-${{ matrix.compiler }}-x86_64.dll"
+          cd dist
+          7z x *.zip
+          php -dextension=./${DLL_NAME} -m | grep biscuit
+
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
@@ -541,6 +645,7 @@ jobs:
       - verify-linux-arm64-musl
       - verify-macos-x86_64
       - verify-macos-arm64
+      - verify-windows
 
     steps:
       - uses: actions/checkout@v6

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(windows, feature(abi_vectorcall))]
+
 mod authorizer;
 mod biscuit;
 mod builders;


### PR DESCRIPTION
Add build-windows and verify-windows jobs covering PHP 8.1–8.5 × ts/nts with correct PIE 1.4 Windows naming convention:
php_biscuit-{VERSION}-{phpver}-{tsmode}-{compiler}-x86_64.zip

Compiler mapping derived from official PHP Windows builds:
- PHP 8.1–8.3: vs16 (Visual Studio 2019)
- PHP 8.4–8.5: vs17 (Visual Studio 2022)

Add #![cfg_attr(windows, feature(abi_vectorcall))] to lib.rs and use nightly Rust toolchain with rustfmt on Windows, required by ext-php-rs due to PHP's __vectorcall calling convention.