### PR TITLE
fix: align extension name across cargo, composer, and PIE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
-          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-x86_64-linux-glibc-${TSMODE}.zip"
+          ARCHIVE_NAME="php_biscuit-php-${VERSION}_php${{ matrix.php-version }}-x86_64-linux-glibc-${TSMODE}.zip"
           mkdir -p dist
-          cp target/x86_64-unknown-linux-gnu/release/libbiscuit.so dist/biscuit.so
+          cp target/x86_64-unknown-linux-gnu/release/libbiscuit_php.so dist/biscuit-php.so
           cd dist
-          zip "${ARCHIVE_NAME}" biscuit.so
-          rm biscuit.so
+          zip "${ARCHIVE_NAME}" biscuit-php.so
+          rm biscuit-php.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -127,12 +127,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
-          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-x86_64-linux-musl-${TSMODE}.zip"
+          ARCHIVE_NAME="php_biscuit-php-${VERSION}_php${{ matrix.php-version }}-x86_64-linux-musl-${TSMODE}.zip"
           mkdir -p dist
-          cp target/release/libbiscuit.so dist/biscuit.so
+          cp target/release/libbiscuit_php.so dist/biscuit-php.so
           cd dist
-          zip "${ARCHIVE_NAME}" biscuit.so
-          rm biscuit.so
+          zip "${ARCHIVE_NAME}" biscuit-php.so
+          rm biscuit-php.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -184,12 +184,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
-          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-arm64-linux-glibc-${TSMODE}.zip"
+          ARCHIVE_NAME="php_biscuit-php-${VERSION}_php${{ matrix.php-version }}-arm64-linux-glibc-${TSMODE}.zip"
           mkdir -p dist
-          cp target/aarch64-unknown-linux-gnu/release/libbiscuit.so dist/biscuit.so
+          cp target/aarch64-unknown-linux-gnu/release/libbiscuit_php.so dist/biscuit-php.so
           cd dist
-          zip "${ARCHIVE_NAME}" biscuit.so
-          rm biscuit.so
+          zip "${ARCHIVE_NAME}" biscuit-php.so
+          rm biscuit-php.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -229,12 +229,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
-          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-arm64-linux-musl-${TSMODE}.zip"
+          ARCHIVE_NAME="php_biscuit-php-${VERSION}_php${{ matrix.php-version }}-arm64-linux-musl-${TSMODE}.zip"
           mkdir -p dist
-          cp target/release/libbiscuit.so dist/biscuit.so
+          cp target/release/libbiscuit_php.so dist/biscuit-php.so
           cd dist
-          zip "${ARCHIVE_NAME}" biscuit.so
-          rm biscuit.so
+          zip "${ARCHIVE_NAME}" biscuit-php.so
+          rm biscuit-php.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -286,12 +286,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
-          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-x86_64-darwin-bsdlibc-${TSMODE}.zip"
+          ARCHIVE_NAME="php_biscuit-php-${VERSION}_php${{ matrix.php-version }}-x86_64-darwin-bsdlibc-${TSMODE}.zip"
           mkdir -p dist
-          cp target/x86_64-apple-darwin/release/libbiscuit.dylib dist/biscuit.so
+          cp target/x86_64-apple-darwin/release/libbiscuit_php.dylib dist/biscuit-php.so
           cd dist
-          zip "${ARCHIVE_NAME}" biscuit.so
-          rm biscuit.so
+          zip "${ARCHIVE_NAME}" biscuit-php.so
+          rm biscuit-php.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -350,9 +350,9 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE="${{ matrix.phpts }}"
-          BASE_NAME="php_biscuit-${VERSION}-${{ matrix.php-version }}-${TSMODE}-${{ matrix.compiler }}-x86_64"
+          BASE_NAME="php_biscuit-php-${VERSION}-${{ matrix.php-version }}-${TSMODE}-${{ matrix.compiler }}-x86_64"
           mkdir -p dist
-          cp target/x86_64-pc-windows-msvc/release/biscuit.dll dist/${BASE_NAME}.dll
+          cp target/x86_64-pc-windows-msvc/release/biscuit_php.dll dist/${BASE_NAME}.dll
           cd dist
           7z a "${BASE_NAME}.zip" "${BASE_NAME}.dll"
           rm "${BASE_NAME}.dll"
@@ -407,12 +407,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE=${{ matrix.phpts == 'ts' && 'zts' || 'nts' }}
-          ARCHIVE_NAME="php_biscuit-${VERSION}_php${{ matrix.php-version }}-arm64-darwin-bsdlibc-${TSMODE}.zip"
+          ARCHIVE_NAME="php_biscuit-php-${VERSION}_php${{ matrix.php-version }}-arm64-darwin-bsdlibc-${TSMODE}.zip"
           mkdir -p dist
-          cp target/aarch64-apple-darwin/release/libbiscuit.dylib dist/biscuit.so
+          cp target/aarch64-apple-darwin/release/libbiscuit_php.dylib dist/biscuit-php.so
           cd dist
-          zip "${ARCHIVE_NAME}" biscuit.so
-          rm biscuit.so
+          zip "${ARCHIVE_NAME}" biscuit-php.so
+          rm biscuit-php.so
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -448,7 +448,7 @@ jobs:
         run: |
           cd dist
           unzip *.zip
-          php -dextension=./biscuit.so -m | grep biscuit
+          php -dextension=./biscuit-php.so -m | grep biscuit-php
 
   verify-linux-x86_64-musl:
     name: Verify Linux x86_64 musl - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
@@ -475,7 +475,7 @@ jobs:
         run: |
           cd dist
           unzip *.zip
-          php -dextension=./biscuit.so -m | grep biscuit
+          php -dextension=./biscuit-php.so -m | grep biscuit-php
 
   verify-linux-arm64:
     name: Verify Linux arm64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
@@ -505,7 +505,7 @@ jobs:
         run: |
           cd dist
           unzip *.zip
-          php -dextension=./biscuit.so -m | grep biscuit
+          php -dextension=./biscuit-php.so -m | grep biscuit-php
 
   verify-linux-arm64-musl:
     name: Verify Linux arm64 musl - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
@@ -532,7 +532,7 @@ jobs:
             sh -c '
               apk add --no-cache unzip &&
               unzip *.zip &&
-              php -dextension=./biscuit.so -m | grep biscuit
+              php -dextension=./biscuit-php.so -m | grep biscuit-php
             '
 
   verify-macos-x86_64:
@@ -563,7 +563,7 @@ jobs:
         run: |
           cd dist
           unzip *.zip
-          php -dextension=./biscuit.so -m | grep biscuit
+          php -dextension=./biscuit-php.so -m | grep biscuit-php
 
   verify-macos-arm64:
     name: Verify macOS arm64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
@@ -593,7 +593,7 @@ jobs:
         run: |
           cd dist
           unzip *.zip
-          php -dextension=./biscuit.so -m | grep biscuit
+          php -dextension=./biscuit-php.so -m | grep biscuit-php
 
   verify-windows:
     name: Verify Windows x86_64 - PHP ${{ matrix.php-version }} (${{ matrix.phpts }})
@@ -630,10 +630,10 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME}"
           TSMODE="${{ matrix.phpts }}"
-          DLL_NAME="php_biscuit-${VERSION}-${{ matrix.php-version }}-${TSMODE}-${{ matrix.compiler }}-x86_64.dll"
+          DLL_NAME="php_biscuit-php-${VERSION}-${{ matrix.php-version }}-${TSMODE}-${{ matrix.compiler }}-x86_64.dll"
           cd dist
           7z x *.zip
-          php -dextension=./${DLL_NAME} -m | grep biscuit
+          php -dextension=./${DLL_NAME} -m | grep biscuit-php
 
   create-release:
     name: Create GitHub Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,4 +63,4 @@ jobs:
           mago lint --reporting-format=github
 
       - name: "Run PHPUnit"
-        run: php -dextension=./target/release/libbiscuit.so vendor/bin/phpunit
+        run: php -dextension=./target/release/libbiscuit_php.so vendor/bin/phpunit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ biscuit-auth = { version = "6.0.0", features = ["pem"] }
 hex = "0.4"
 
 [lib]
-name = "biscuit"
+name = "biscuit_php"
 crate-type = ["cdylib"]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -22,28 +22,25 @@ PHP bindings for [Biscuit](https://www.biscuitsec.org), a bearer token supportin
 
 ### Pre-built Binaries (Recommended)
 
-Pre-built binaries are available for Linux x86_64 across multiple PHP versions, with both Thread-Safe (TS) and Non-Thread-Safe (NTS) variants. Download the appropriate binary for your PHP version and thread safety from the [latest release](https://github.com/ptondereau/biscuit-php/releases/latest).
+Pre-built binaries are available for Linux (glibc/musl, x86_64/arm64), macOS (x86_64/arm64), and Windows (x86_64) across PHP 8.1 through 8.5, with both Thread-Safe (TS) and Non-Thread-Safe (NTS) variants. Download the appropriate archive for your platform from the [latest release](https://github.com/ptondereau/biscuit-php/releases/latest).
 
-#### Quick Installation
+#### Quick Installation (Linux glibc x86_64, PHP 8.3 NTS shown)
 
 ```bash
-# Download binary for your PHP version and thread safety
-# Replace 8.3 with your version and ts/nts based on your thread safety
-wget https://github.com/ptondereau/biscuit-php/releases/latest/download/ext_biscuit_php-linux-x86_64-php8.3-nts.so
-
-# Verify checksum
-wget https://github.com/ptondereau/biscuit-php/releases/latest/download/ext_biscuit_php-linux-x86_64-php8.3-nts.so.sha256
-sha256sum -c ext_biscuit_php-linux-x86_64-php8.3-nts.so.sha256
+# Pick the archive matching your PHP version, libc, arch, and TS/NTS:
+VERSION=v0.4.0
+wget https://github.com/ptondereau/biscuit-php/releases/download/${VERSION}/php_biscuit-php-${VERSION}_php8.3-x86_64-linux-glibc-nts.zip
+unzip php_biscuit-php-${VERSION}_php8.3-x86_64-linux-glibc-nts.zip
 
 # Move to PHP extension directory (adjust path for your system)
-sudo mv ext_biscuit_php-linux-x86_64-php8.3-nts.so /usr/lib/php/$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')/
+sudo mv biscuit-php.so /usr/lib/php/$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')/
 
 # Enable the extension
-echo "extension=ext_biscuit_php-linux-x86_64-php8.3-nts.so" | sudo tee /etc/php/$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')/mods-available/biscuit.ini
-sudo phpenmod biscuit
+echo "extension=biscuit-php.so" | sudo tee /etc/php/$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')/mods-available/biscuit-php.ini
+sudo phpenmod biscuit-php
 
 # Verify installation
-php -m | grep biscuit
+php -m | grep biscuit-php
 ```
 
 ### PIE installation
@@ -57,7 +54,7 @@ and you can add in your `composer.json`:
 ```json
 {
     // ...
-    "ext-biscuit": "*",
+    "ext-biscuit-php": "*",
     // ...
 }
 ```
@@ -79,7 +76,7 @@ composer install
 cargo build --release
 
 # Load the extension
-php -dextension=target/release/libext_biscuit_php.so -m | grep biscuit
+php -dextension=target/release/libbiscuit_php.so -m | grep biscuit-php
 ```
 
 ### Using stubs for autocompletion
@@ -232,7 +229,7 @@ $publicKey = PublicKey::fromBytes($bytes, Algorithm::Secp256r1); // Explicit Sec
 ```bash
 cargo build
 php \
-    -dextension=target/debug/libext_biscuit_php.so \
+    -dextension=target/debug/libbiscuit_php.so \
     vendor/bin/phpunit
 ```
 
@@ -244,7 +241,7 @@ We're using [Mago](https://mago.carthage.software/) as code-style formatter for 
 composer install
 cargo build
 php \
-    -dextension=target/debug/libext_biscuit_php.so \
+    -dextension=target/debug/libbiscuit_php.so \
     vendor/bin/mago lint // and format
 ```
 
@@ -253,7 +250,7 @@ php \
 ```bash
 cargo build
 php \
-    -dextension=target/debug/libext_biscuit_php.so \
+    -dextension=target/debug/libbiscuit_php.so \
     php-extension-stub-generator.phar dump-files ext-biscuit-php stubs
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,71 @@
 # Upgrading Guide
 
+## Upgrading from v0.3.x to v0.4.0
+
+v0.4.0 aligns the extension name across the Rust crate, the `.so` filename, the Composer `extension-name`, and what `php -m` reports. There are no API changes; the migration is purely about how the extension is named, packaged, and loaded.
+
+### What changed
+
+| Concern | Before (v0.3.x) | After (v0.4.0) |
+|---------|-----------------|----------------|
+| Registered PHP module name (`php -m`) | `biscuit-php` | `biscuit-php` (unchanged) |
+| Cargo `[lib]` name | `biscuit` | `biscuit_php` |
+| Local cargo build output | `libbiscuit.so` | `libbiscuit_php.so` |
+| Composer `php-ext.extension-name` | `biscuit` | `biscuit-php` |
+| PIE-installed file | `biscuit.so` | `biscuit-php.so` |
+| Linux/macOS release archive prefix | `php_biscuit-` | `php_biscuit-php-` |
+| `extension=` directive in php.ini | `extension=biscuit.so` | `extension=biscuit-php.so` |
+
+The Composer ext requirement was already `ext-biscuit-php` in practice (because `php -m` reported `biscuit-php`); v0.4.0 just makes every other surface agree with that. See [issue #30](https://github.com/ptondereau/biscuit-php/issues/30) for context.
+
+### Migration
+
+**1. Composer requires**
+
+If your `composer.json` was working before, no change is needed:
+
+```json
+"require": {
+    "ext-biscuit-php": "*"
+}
+```
+
+If you were following the old README and used `"ext-biscuit"`, change it to `"ext-biscuit-php"`.
+
+**2. PIE users**
+
+```bash
+pie install ptondereau/biscuit-php:^0.4
+```
+
+Then enable the new filename:
+
+```bash
+docker-php-ext-enable biscuit-php
+# or, manually:
+# extension=biscuit-php.so
+```
+
+If you previously enabled `biscuit`, disable it (`docker-php-ext-disable biscuit` or remove the old `extension=biscuit.so` line) before enabling `biscuit-php` to avoid loading the module twice.
+
+**3. Manual install (zip from GitHub release)**
+
+The archive name now starts with `php_biscuit-php-` and contains `biscuit-php.so` rather than `biscuit.so`. Update your `extension=` line in php.ini accordingly.
+
+**4. Building from source**
+
+`cargo build` now produces `libbiscuit_php.so` (not `libbiscuit.so`). Update any local scripts:
+
+```bash
+# Before
+php -dextension=./target/release/libbiscuit.so vendor/bin/phpunit
+
+# After
+php -dextension=./target/release/libbiscuit_php.so vendor/bin/phpunit
+```
+
+---
+
 ## Upgrading from v0.2.x to v0.3.0
 
 v0.3.0 introduces API simplification changes that consolidate redundant methods and add optional parameters to constructors. This is a **breaking change** release.

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "php-ext": {
         "build-path": "pie",
-        "extension-name": "biscuit",
+        "extension-name": "biscuit-php",
         "support-zts": true,
         "support-nts": true,
         "download-url-method": ["pre-packaged-binary", "composer-default"],

--- a/pie/config.m4
+++ b/pie/config.m4
@@ -18,7 +18,8 @@ if test "$PHP_DEBUG" == "yes"; then
   CARGO_BUILD_DIR="target/debug"
 fi
 cat >>Makefile.objects<< EOF
-EXT_NAME = biscuit
+EXT_LIB_NAME = biscuit_php
+EXT_INSTALL_NAME = biscuit-php
 all: cargo_build
 
 clean: cargo_clean
@@ -26,7 +27,7 @@ clean: cargo_clean
 cargo_build:
 	@echo "Building the Rust extension"
 	PHP_CONFIG=$(which $PHP_PHP_CONFIG) PHP=$PHP_EXECUTABLE cargo build $CARGO_FLAGS
-	cp $CARGO_BUILD_DIR/AS_ESCAPE([lib$(EXT_NAME)]).so AS_ESCAPE([$(phplibdir)])/AS_ESCAPE([$(EXT_NAME)]).so
+	cp $CARGO_BUILD_DIR/AS_ESCAPE([lib$(EXT_LIB_NAME)]).so AS_ESCAPE([$(phplibdir)])/AS_ESCAPE([$(EXT_INSTALL_NAME)]).so
 
 cargo_clean:
 	@echo "Cleaning the Rust extension"


### PR DESCRIPTION
The extension registers in PHP as `biscuit-php` (from CARGO_PKG_NAME, used by ext-php-rs's `#[php_module]` macro), but the `.so` file was `biscuit.so` and `composer.json` declared `extension-name: biscuit`. PIE's auto-enable step then queries `extension_loaded("biscuit")` after install and gets false, even though the module is loaded under `biscuit-php`. That's why `pie install` fails to enable the extension.

Aligns every surface on `biscuit-php`:
- `[lib] name = "biscuit_php"` so cargo produces `libbiscuit_php.so` (Rust forces underscore)
- `pie/config.m4` installs the file as `biscuit-php.so`
- `composer.json` `extension-name: biscuit-php`
- Release archives renamed to `php_biscuit-php-...zip` and contain `biscuit-php.so`
- README install / build commands updated
- UPGRADING.md gets a v0.4.0 section explaining the rename

Refs #30