### PR TITLE
feat: structured exception hierarchy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "regex",
  "serde_json",
  "sha2 0.9.9",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "zeroize",
 ]
@@ -97,7 +97,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -116,11 +116,13 @@ dependencies = [
 
 [[package]]
 name = "biscuit_php"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "biscuit-auth",
+ "biscuit-parser",
  "ext-php-rs",
  "hex",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -530,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "ext-php-rs"
-version = "0.15.12"
+version = "0.15.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0525834a3e26fdf0a60a8e7c27ec9521a35808eba8e41a15e135c22f670bc937"
+checksum = "89ba219f32e80a5ab8b2562b873f15aeac8028aff1fb1a898409b2e251bfe59d"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1685,7 +1687,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1693,6 +1704,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "biscuit_php"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "PHP wrapper for Biscuit authorization tokens"
 authors = ["Pierre Tondereau <pierre.tondereau@protonmail.com>"]
 
 [dependencies]
-ext-php-rs = "0.15.12"
+ext-php-rs = "0.15.13"
 biscuit-auth = { version = "6.0.0", features = ["pem"] }
+biscuit-parser = "0.2.0"
 hex = "0.4"
+thiserror = "2"
 
 [lib]
 name = "biscuit_php"

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,313 @@
 # Upgrading Guide
 
+## Upgrading from v0.4.x to v0.5.0
+
+v0.5.0 replaces the flat list of `Invalid*` exception classes with a deep typed hierarchy under a shared `BiscuitException` base, and attaches structured payloads to `AuthorizationException` (matched policy and failed checks) and to all `DatalogException` subclasses (parse errors and parameter binding info). Every failure shape now has its own concrete exception class so callers can use idiomatic multi-catch instead of branching on a message string.
+
+See [issue #14](https://github.com/ptondereau/biscuit-php/issues/14).
+
+### What changed
+
+#### Exception hierarchy
+
+Every extension-thrown exception now extends `Biscuit\Exception\BiscuitException`, which extends `\Exception`. `catch (BiscuitException $e)` is the new catch-all idiom. Each failure category has a base class (`KeyException`, `DatalogException`, `FormatException`, `BuildException`) with concrete per-kind subclasses you can catch directly.
+
+| Before (v0.4.x) | After (v0.5.0) |
+|---|---|
+| `InvalidPublicKey` | `PublicKeyException` extends `KeyException` |
+| `InvalidPrivateKey` | `PrivateKeyException` extends `KeyException` |
+| `InvalidFact` | `FactException` extends `DatalogException` |
+| `InvalidRule` | `RuleException` extends `DatalogException` |
+| `InvalidCheck` | `CheckException` extends `DatalogException` |
+| `InvalidPolicy` | `PolicyException` extends `DatalogException` |
+| `InvalidTerm` | `TermException` extends `DatalogException` |
+| (Datalog scope failures, previously bundled into `InvalidTerm`) | `ScopeException` extends `DatalogException` |
+| (Token base64 errors, previously raw `\Exception`) | `Base64Exception` extends `FormatException` |
+| (Token byte errors, previously raw `\Exception`) | `BytesException` extends `FormatException` |
+| (Token signature errors, previously raw `\Exception`) | `SignatureException` extends `FormatException` |
+| (Snapshot / block-source errors, previously raw `\Exception`) | `SnapshotException` extends `FormatException` |
+| (`BiscuitBuilder::build()` failures, previously raw `\Exception`) | `BiscuitBuildException` extends `BuildException` |
+| (`Biscuit::append()` failures, previously raw `\Exception`) | `BlockAppendException` extends `BuildException` |
+| (`AuthorizerBuilder::build()` / `query()` failures, previously raw `\Exception`) | `AuthorizerBuildException` extends `BuildException` |
+| (`Biscuit::appendThirdParty()` failures, previously raw `\Exception`) | `ThirdPartyBlockAppendException` extends `BuildException` |
+| `AuthorizerError` | `AuthorizationException` extends `BiscuitException` |
+| `ThirdPartyRequestError` | `ThirdPartyException` extends `BiscuitException` |
+| `BuilderConsumed` | `BuilderStateException` extends `BiscuitException` |
+
+The class identity replaces the `getCode()` kind discriminant from earlier proposals: `catch (FactException $e)` is the v0.5.0 idiom rather than `catch (DatalogException $e) { if ($e->getCode() === 1) ... }`. `getCode()` returns the standard PHP `Throwable` default (0) on these exceptions; rely on the class hierarchy instead.
+
+You can still catch a category at the base level (for example `catch (DatalogException $e)`) and let inheritance route any of its subclasses to that handler.
+
+#### Structured payloads
+
+| Class | New accessors |
+|---|---|
+| `AuthorizationException` | `getMatchedPolicy(): ?MatchedPolicy`, `getFailedChecks(): array<FailedCheck>` |
+| Every `DatalogException` subclass (`FactException`, `RuleException`, `CheckException`, `PolicyException`, `TermException`, `ScopeException`) | `getParseErrors(): ?array<ParseError>`, `getMissingParameters(): ?array<string>`, `getUnusedParameters(): ?array<string>` |
+
+New value objects:
+
+| Class | Accessors |
+|---|---|
+| `Biscuit\Auth\MatchedPolicy` | `getKind(): string` (`"allow"` or `"deny"`), `getPolicyId(): int`, `getCode(): ?string` |
+| `Biscuit\Auth\FailedCheck` | `getOrigin(): string` (`"block"` or `"authorizer"`), `getBlockId(): ?int`, `getCheckId(): int`, `getRule(): string` |
+| `Biscuit\Auth\ParseError` | `getInput(): string`, `getMessage(): ?string` |
+
+#### Other
+
+- `Authorizer::authorize()` returns `Biscuit\Auth\MatchedPolicy` instead of `int`.
+- The full upstream `Error::source()` chain is joined into `getMessage()`, so a `DatalogException` message now includes the parser error context.
+
+### Migration
+
+#### Renaming `Invalid*` Datalog catches
+
+Before:
+```php
+use Biscuit\Exception\InvalidFact;
+use Biscuit\Exception\InvalidRule;
+use Biscuit\Exception\InvalidCheck;
+use Biscuit\Exception\InvalidPolicy;
+use Biscuit\Exception\InvalidTerm;
+
+try {
+    new Fact('not valid');
+} catch (InvalidFact $e) {
+    log($e->getMessage());
+}
+```
+
+After:
+```php
+use Biscuit\Exception\FactException;
+
+try {
+    new Fact('not valid');
+} catch (FactException $e) {
+    log($e->getMessage());
+}
+```
+
+Multi-catch lets you react to different Datalog failure shapes in one block:
+```php
+use Biscuit\Exception\FactException;
+use Biscuit\Exception\RuleException;
+use Biscuit\Exception\TermException;
+
+try {
+    $fact = new Fact('user({id})');
+    $fact->set('id', $userId);
+} catch (FactException $e) {
+    // bad Fact source
+} catch (TermException $e) {
+    // bad term value passed to set()
+} catch (RuleException $e) {
+    // bad Rule source or binding
+}
+```
+
+#### Renaming key catches
+
+Before:
+```php
+use Biscuit\Exception\InvalidPublicKey;
+use Biscuit\Exception\InvalidPrivateKey;
+
+try {
+    new PublicKey($maybeBadHex);
+} catch (InvalidPublicKey $e) { /* ... */ }
+
+try {
+    new PrivateKey($maybeBadHex);
+} catch (InvalidPrivateKey $e) { /* ... */ }
+```
+
+After:
+```php
+use Biscuit\Exception\PrivateKeyException;
+use Biscuit\Exception\PublicKeyException;
+
+try {
+    new PublicKey($maybeBadHex);
+} catch (PublicKeyException $e) { /* ... */ }
+
+try {
+    new PrivateKey($maybeBadHex);
+} catch (PrivateKeyException $e) { /* ... */ }
+```
+
+#### Catching builder-state errors
+
+Before:
+```php
+use Biscuit\Exception\BuilderConsumed;
+
+try {
+    $blockBuilder->addCode('...'); // after a merge
+} catch (BuilderConsumed $e) { /* ... */ }
+```
+
+After:
+```php
+use Biscuit\Exception\BuilderStateException;
+
+try {
+    $blockBuilder->addCode('...');
+} catch (BuilderStateException $e) { /* ... */ }
+```
+
+#### Catching third-party flow errors
+
+Before:
+```php
+use Biscuit\Exception\ThirdPartyRequestError;
+
+try {
+    $request->createBlock($key, $block);
+} catch (ThirdPartyRequestError $e) { /* ... */ }
+```
+
+After:
+```php
+use Biscuit\Exception\ThirdPartyException;
+
+try {
+    $request->createBlock($key, $block);
+} catch (ThirdPartyException $e) { /* ... */ }
+```
+
+#### Authorization
+
+`Authorizer::authorize()` now returns a `Biscuit\Auth\MatchedPolicy` carrying the policy kind, id, and source code. Failures throw `AuthorizationException` with structured matched-policy and failed-checks accessors.
+
+Before:
+```php
+use Biscuit\Exception\AuthorizerError;
+
+$idx = $authorizer->authorize();
+if ($idx === 0) {
+    // first allow policy matched
+}
+```
+
+After:
+```php
+use Biscuit\Exception\AuthorizationException;
+
+try {
+    $policy = $authorizer->authorize();
+    log(sprintf('matched %s policy #%d', $policy->getKind(), $policy->getPolicyId()));
+} catch (AuthorizationException $e) {
+    $matched = $e->getMatchedPolicy();
+    if ($matched !== null) {
+        log(sprintf(
+            'rejected by %s policy #%d: %s',
+            $matched->getKind(),
+            $matched->getPolicyId(),
+            $matched->getCode(),
+        ));
+    }
+
+    foreach ($e->getFailedChecks() as $check) {
+        log(sprintf(
+            '%s check #%d failed: %s',
+            $check->getOrigin(),
+            $check->getCheckId(),
+            $check->getRule(),
+        ));
+    }
+}
+```
+
+A `null` matched policy means no policy matched at all (the `Logic::NoMatchingPolicy` upstream case); the failed-checks list still tells you which conditions blocked authorization.
+
+#### Inspecting Datalog failures
+
+Every `DatalogException` subclass carries the upstream `LanguageError` payload when there is one. Use it to surface parse errors and parameter-binding issues without parsing the message.
+
+Parse failure:
+```php
+use Biscuit\Auth\Fact;
+use Biscuit\Auth\ParseError;
+use Biscuit\Exception\FactException;
+
+try {
+    new Fact('not valid datalog');
+} catch (FactException $e) {
+    $parseErrors = $e->getParseErrors();
+    if ($parseErrors !== null) {
+        foreach ($parseErrors as $parseError) {
+            log(sprintf(
+                'parse error at %s: %s',
+                $parseError->getInput(),
+                $parseError->getMessage() ?? '(no message)',
+            ));
+        }
+    }
+}
+```
+
+Unused parameter (the parameter map's extra keys surface at term-binding time):
+```php
+use Biscuit\Auth\Rule;
+use Biscuit\Exception\TermException;
+
+try {
+    new Rule('foo({x}) <- bar({y})', ['z' => 1]);
+} catch (TermException $e) {
+    $unused = $e->getUnusedParameters();
+    if ($unused !== null) {
+        log('unused params: ' . implode(', ', $unused));
+    }
+}
+```
+
+Missing parameter at builder time:
+```php
+use Biscuit\Auth\BiscuitBuilder;
+use Biscuit\Auth\Rule;
+use Biscuit\Exception\RuleException;
+
+$rule = new Rule('foo({x}) <- bar({y})');
+
+try {
+    $builder = new BiscuitBuilder();
+    $builder->addRule($rule);
+} catch (RuleException $e) {
+    $missing = $e->getMissingParameters();
+    if ($missing !== null) {
+        log('missing params: ' . implode(', ', $missing));
+    }
+}
+```
+
+If you do not care about which Datalog kind failed, catch the `DatalogException` base instead and the three accessors are still available. When the failure is not a Datalog parse or parameter issue (for example, a `null` value passed to `Fact::set()`), all three accessors return `null` and you can fall back to `getMessage()`.
+
+#### Catching everything at once
+
+If you do not need to distinguish failure shapes, the new base class is enough:
+
+```php
+use Biscuit\Exception\BiscuitException;
+
+try {
+    // anything from this extension
+} catch (BiscuitException $e) {
+    log($e->getMessage());
+}
+```
+
+### Quick Migration Checklist
+
+- [ ] Replace every `Invalid{Fact,Rule,Check,Policy,Term}` catch with the matching `{Fact,Rule,Check,Policy,Term}Exception` from `Biscuit\Exception`.
+- [ ] Replace every `Invalid{Public,Private}Key` catch with `{Public,Private}KeyException` from `Biscuit\Exception`.
+- [ ] Replace every `AuthorizerError` catch with `AuthorizationException`.
+- [ ] Replace every `BuilderConsumed` catch with `BuilderStateException`.
+- [ ] Replace every `ThirdPartyRequestError` catch with `ThirdPartyException`.
+- [ ] Replace every `$result = $authorizer->authorize(); /* use as int */` with `MatchedPolicy` access (`->getPolicyId()`).
+- [ ] If you previously wrapped token parsing or building in a bare `\Exception` catch, narrow it to the relevant `Base64Exception` / `BytesException` / `SignatureException` / `SnapshotException` / `BiscuitBuildException` / `BlockAppendException` / `AuthorizerBuildException` / `ThirdPartyBlockAppendException`.
+- [ ] Optional: enrich logging with `getMatchedPolicy()` / `getFailedChecks()` (authorization failures) and `getParseErrors()` / `getMissingParameters()` / `getUnusedParameters()` (datalog failures) for actionable diagnostics.
+
 ## Upgrading from v0.3.x to v0.4.0
 
 v0.4.0 aligns the extension name across the Rust crate, the `.so` filename, the Composer `extension-name`, and what `php -m` reports. There are no API changes; the migration is purely about how the extension is named, packaged, and loaded.

--- a/biscuit-php.stubs.php
+++ b/biscuit-php.stubs.php
@@ -1,6 +1,6 @@
 <?php
 
-// Stubs for biscuit-php
+// Stubs for biscuit_php
 
 namespace Biscuit\Auth {
     enum Algorithm: int {
@@ -17,9 +17,9 @@ namespace Biscuit\Auth {
         public function __toString(): string {}
 
         /**
-         * @return int
+         * @return \Biscuit\Auth\MatchedPolicy
          */
-        public function authorize(): int {}
+        public function authorize(): \Biscuit\Auth\MatchedPolicy {}
 
         /**
          * @return string
@@ -385,6 +385,30 @@ namespace Biscuit\Auth {
         public function set(string $name, mixed $value): void {}
     }
 
+    class FailedCheck {
+        public function __construct() {}
+
+        /**
+         * @return int|null
+         */
+        public function getBlockId(): ?int {}
+
+        /**
+         * @return int
+         */
+        public function getCheckId(): int {}
+
+        /**
+         * @return string
+         */
+        public function getOrigin(): string {}
+
+        /**
+         * @return string
+         */
+        public function getRule(): string {}
+    }
+
     class KeyPair {
         /**
          * @param \Biscuit\Auth\Algorithm|null $alg
@@ -406,6 +430,39 @@ namespace Biscuit\Auth {
          * @return \Biscuit\Auth\PublicKey
          */
         public function getPublicKey(): \Biscuit\Auth\PublicKey {}
+    }
+
+    class MatchedPolicy {
+        public function __construct() {}
+
+        /**
+         * @return string|null
+         */
+        public function getCode(): ?string {}
+
+        /**
+         * @return string
+         */
+        public function getKind(): string {}
+
+        /**
+         * @return int
+         */
+        public function getPolicyId(): int {}
+    }
+
+    class ParseError {
+        public function __construct() {}
+
+        /**
+         * @return string
+         */
+        public function getInput(): string {}
+
+        /**
+         * @return string|null
+         */
+        public function getMessage(): ?string {}
     }
 
     class Policy {
@@ -621,43 +678,228 @@ namespace Biscuit\Auth {
 }
 
 namespace Biscuit\Exception {
-    class AuthorizerError extends \Exception {
+    class AuthorizationException extends Biscuit\Exception\BiscuitException {
+        protected string $message;
+
+        public function __construct() {}
+
+        /**
+         * @return array
+         */
+        public function getFailedChecks(): array {}
+
+        /**
+         * @return \Biscuit\Auth\MatchedPolicy|null
+         */
+        public function getMatchedPolicy(): ?\Biscuit\Auth\MatchedPolicy {}
+    }
+
+    class AuthorizerBuildException extends Biscuit\Exception\BuildException {
         public function __construct() {}
     }
 
-    class BuilderConsumed extends \Exception {
+    class Base64Exception extends Biscuit\Exception\FormatException {
         public function __construct() {}
     }
 
-    class InvalidCheck extends \Exception {
+    class BiscuitBuildException extends Biscuit\Exception\BuildException {
         public function __construct() {}
     }
 
-    class InvalidFact extends \Exception {
+    class BiscuitException extends \Exception {
         public function __construct() {}
     }
 
-    class InvalidPolicy extends \Exception {
+    class BlockAppendException extends Biscuit\Exception\BuildException {
         public function __construct() {}
     }
 
-    class InvalidPrivateKey extends \Exception {
+    class BuildException extends Biscuit\Exception\BiscuitException {
         public function __construct() {}
     }
 
-    class InvalidPublicKey extends \Exception {
+    class BuilderStateException extends Biscuit\Exception\BiscuitException {
         public function __construct() {}
     }
 
-    class InvalidRule extends \Exception {
+    class BytesException extends Biscuit\Exception\FormatException {
         public function __construct() {}
     }
 
-    class InvalidTerm extends \Exception {
+    class CheckException extends Biscuit\Exception\DatalogException {
+        protected string $message;
+
+        public function __construct() {}
+
+        /**
+         * @return array|null
+         */
+        public function getMissingParameters(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getParseErrors(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getUnusedParameters(): ?array {}
+    }
+
+    class DatalogException extends Biscuit\Exception\BiscuitException {
+        public function __construct() {}
+
+        /**
+         * @return array|null
+         */
+        public function getMissingParameters(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getParseErrors(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getUnusedParameters(): ?array {}
+    }
+
+    class FactException extends Biscuit\Exception\DatalogException {
+        protected string $message;
+
+        public function __construct() {}
+
+        /**
+         * @return array|null
+         */
+        public function getMissingParameters(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getParseErrors(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getUnusedParameters(): ?array {}
+    }
+
+    class FormatException extends Biscuit\Exception\BiscuitException {
         public function __construct() {}
     }
 
-    class ThirdPartyRequestError extends \Exception {
+    class KeyException extends Biscuit\Exception\BiscuitException {
+        public function __construct() {}
+    }
+
+    class PolicyException extends Biscuit\Exception\DatalogException {
+        protected string $message;
+
+        public function __construct() {}
+
+        /**
+         * @return array|null
+         */
+        public function getMissingParameters(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getParseErrors(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getUnusedParameters(): ?array {}
+    }
+
+    class PrivateKeyException extends Biscuit\Exception\KeyException {
+        public function __construct() {}
+    }
+
+    class PublicKeyException extends Biscuit\Exception\KeyException {
+        public function __construct() {}
+    }
+
+    class RuleException extends Biscuit\Exception\DatalogException {
+        protected string $message;
+
+        public function __construct() {}
+
+        /**
+         * @return array|null
+         */
+        public function getMissingParameters(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getParseErrors(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getUnusedParameters(): ?array {}
+    }
+
+    class ScopeException extends Biscuit\Exception\DatalogException {
+        protected string $message;
+
+        public function __construct() {}
+
+        /**
+         * @return array|null
+         */
+        public function getMissingParameters(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getParseErrors(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getUnusedParameters(): ?array {}
+    }
+
+    class SignatureException extends Biscuit\Exception\FormatException {
+        public function __construct() {}
+    }
+
+    class SnapshotException extends Biscuit\Exception\FormatException {
+        public function __construct() {}
+    }
+
+    class TermException extends Biscuit\Exception\DatalogException {
+        protected string $message;
+
+        public function __construct() {}
+
+        /**
+         * @return array|null
+         */
+        public function getMissingParameters(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getParseErrors(): ?array {}
+
+        /**
+         * @return array|null
+         */
+        public function getUnusedParameters(): ?array {}
+    }
+
+    class ThirdPartyBlockAppendException extends Biscuit\Exception\BuildException {
+        public function __construct() {}
+    }
+
+    class ThirdPartyException extends Biscuit\Exception\BiscuitException {
         public function __construct() {}
     }
 }

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,0 +1,171 @@
+use biscuit_auth::error::{
+    FailedAuthorizerCheck, FailedBlockCheck, FailedCheck as UpstreamFailedCheck,
+    MatchedPolicy as UpstreamMatchedPolicy,
+};
+use ext_php_rs::prelude::*;
+
+use crate::errors::BiscuitException;
+
+#[php_class]
+#[php(name = "Biscuit\\Auth\\MatchedPolicy")]
+#[derive(Debug, Clone)]
+pub struct MatchedPolicy {
+    kind: PolicyKind,
+    policy_id: i64,
+    code: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PolicyKind {
+    Allow,
+    Deny,
+}
+
+impl PolicyKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            PolicyKind::Allow => "allow",
+            PolicyKind::Deny => "deny",
+        }
+    }
+}
+
+impl MatchedPolicy {
+    pub(crate) fn from_upstream(
+        policy: &UpstreamMatchedPolicy,
+        policies: &[biscuit_auth::builder::Policy],
+    ) -> Self {
+        let (kind, idx) = match policy {
+            UpstreamMatchedPolicy::Allow(i) => (PolicyKind::Allow, *i),
+            UpstreamMatchedPolicy::Deny(i) => (PolicyKind::Deny, *i),
+        };
+        let code = policies.get(idx).map(ToString::to_string);
+        Self {
+            kind,
+            policy_id: idx as i64,
+            code,
+        }
+    }
+
+    pub(crate) fn allow(policy_id: usize, code: Option<String>) -> Self {
+        Self {
+            kind: PolicyKind::Allow,
+            policy_id: policy_id as i64,
+            code,
+        }
+    }
+}
+
+#[php_impl]
+impl MatchedPolicy {
+    pub fn get_kind(&self) -> String {
+        self.kind.as_str().to_string()
+    }
+
+    pub fn get_policy_id(&self) -> i64 {
+        self.policy_id
+    }
+
+    pub fn get_code(&self) -> Option<String> {
+        self.code.clone()
+    }
+}
+
+#[php_class]
+#[php(name = "Biscuit\\Auth\\FailedCheck")]
+#[derive(Debug, Clone)]
+pub struct FailedCheck {
+    origin: CheckOrigin,
+    block_id: Option<i64>,
+    check_id: i64,
+    rule: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CheckOrigin {
+    Block,
+    Authorizer,
+}
+
+impl CheckOrigin {
+    fn as_str(self) -> &'static str {
+        match self {
+            CheckOrigin::Block => "block",
+            CheckOrigin::Authorizer => "authorizer",
+        }
+    }
+}
+
+impl FailedCheck {
+    pub(crate) fn from_upstream(check: &UpstreamFailedCheck) -> Self {
+        match check {
+            UpstreamFailedCheck::Block(FailedBlockCheck {
+                block_id,
+                check_id,
+                rule,
+            }) => Self {
+                origin: CheckOrigin::Block,
+                block_id: Some(i64::from(*block_id)),
+                check_id: i64::from(*check_id),
+                rule: rule.clone(),
+            },
+            UpstreamFailedCheck::Authorizer(FailedAuthorizerCheck { check_id, rule }) => Self {
+                origin: CheckOrigin::Authorizer,
+                block_id: None,
+                check_id: i64::from(*check_id),
+                rule: rule.clone(),
+            },
+        }
+    }
+}
+
+#[php_impl]
+impl FailedCheck {
+    pub fn get_origin(&self) -> String {
+        self.origin.as_str().to_string()
+    }
+
+    pub fn get_block_id(&self) -> Option<i64> {
+        self.block_id
+    }
+
+    pub fn get_check_id(&self) -> i64 {
+        self.check_id
+    }
+
+    pub fn get_rule(&self) -> String {
+        self.rule.clone()
+    }
+}
+
+#[php_class]
+#[php(name = "Biscuit\\Exception\\AuthorizationException")]
+#[php(extends(BiscuitException))]
+#[derive(Debug, Clone, Default)]
+pub struct AuthorizationException {
+    matched_policy: Option<MatchedPolicy>,
+    failed_checks: Vec<FailedCheck>,
+}
+
+impl AuthorizationException {
+    pub(crate) fn new(
+        matched_policy: Option<MatchedPolicy>,
+        failed_checks: Vec<FailedCheck>,
+    ) -> Self {
+        Self {
+            matched_policy,
+            failed_checks,
+        }
+    }
+}
+
+#[php_impl]
+impl AuthorizationException {
+    pub fn get_matched_policy(&self) -> Option<MatchedPolicy> {
+        self.matched_policy.clone()
+    }
+
+    pub fn get_failed_checks(&self) -> Vec<FailedCheck> {
+        self.failed_checks.clone()
+    }
+}

--- a/src/authorizer.rs
+++ b/src/authorizer.rs
@@ -3,10 +3,11 @@ use std::collections::HashMap;
 use ext_php_rs::binary_slice::BinarySlice;
 use ext_php_rs::prelude::*;
 
+use crate::authorization::MatchedPolicy;
 use crate::biscuit::Biscuit;
 use crate::builders::BlockBuilder;
 use crate::datalog::{Check, Fact, Policy, Rule};
-use crate::errors::AuthorizerError;
+use crate::errors::{BiscuitError, BuildKind, DatalogKind, FormatKind, ResultExt};
 use crate::helpers::{MixedValue, get_builder, mixed_value_to_term, take_builder};
 use crate::keys::PublicKey;
 
@@ -17,43 +18,44 @@ pub struct Authorizer(biscuit_auth::Authorizer);
 
 #[php_impl]
 impl Authorizer {
-    pub fn authorize(&mut self) -> PhpResult<usize> {
-        self.0
-            .authorize()
-            .map_err(|e| PhpException::from_class::<AuthorizerError>(e.to_string()))
+    pub fn authorize(&mut self) -> PhpResult<MatchedPolicy> {
+        let (_, _, _, policies) = self.0.dump();
+        match self.0.authorize() {
+            Ok(idx) => {
+                let code = policies.get(idx).map(ToString::to_string);
+                Ok(MatchedPolicy::allow(idx, code))
+            }
+            Err(err) => Err(BiscuitError::authorization(err, policies).into()),
+        }
     }
 
     pub fn query(&mut self, rule: &Rule) -> PhpResult<Vec<Fact>> {
-        let facts: Result<Vec<biscuit_auth::builder::Fact>, _> = self.0.query(rule.0.clone());
-        facts
-            .map(|f| f.iter().map(|fact| Fact(fact.clone())).collect())
-            .map_err(|e| PhpException::from_class::<AuthorizerError>(e.to_string()))
+        let facts: Vec<biscuit_auth::builder::Fact> =
+            self.0.query(rule.0.clone()).build(BuildKind::Authorizer)?;
+        Ok(facts.into_iter().map(Fact).collect())
     }
 
     pub fn base64_snapshot(&self) -> PhpResult<String> {
-        self.0
-            .to_base64_snapshot()
-            .map_err(|e| PhpException::default(format!("Serialization error: {}", e)))
+        Ok(self.0.to_base64_snapshot().format(FormatKind::Snapshot)?)
     }
 
     pub fn raw_snapshot(&self) -> PhpResult<Vec<u8>> {
-        self.0
-            .to_raw_snapshot()
-            .map_err(|e| PhpException::default(format!("Serialization error: {}", e)))
+        Ok(self.0.to_raw_snapshot().format(FormatKind::Snapshot)?)
     }
 
     #[php(name = "fromBase64Snapshot")]
     pub fn from_base64_snapshot(input: &str) -> PhpResult<Self> {
-        biscuit_auth::Authorizer::from_base64_snapshot(input)
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Validation error: {}", e)))
+        Ok(Self(
+            biscuit_auth::Authorizer::from_base64_snapshot(input).format(FormatKind::Snapshot)?,
+        ))
     }
 
     #[php(name = "fromRawSnapshot")]
     pub fn from_raw_snapshot(input: BinarySlice<u8>) -> PhpResult<Self> {
-        biscuit_auth::Authorizer::from_raw_snapshot(input.as_ref())
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Validation error: {}", e)))
+        Ok(Self(
+            biscuit_auth::Authorizer::from_raw_snapshot(input.as_ref())
+                .format(FormatKind::Snapshot)?,
+        ))
     }
 
     pub fn __to_string(&self) -> String {
@@ -90,7 +92,7 @@ impl AuthorizerBuilder {
             Some(p) => p
                 .iter()
                 .map(|(k, v)| mixed_value_to_term(v).map(|term| (k.clone(), term)))
-                .collect::<Result<HashMap<String, biscuit_auth::builder::Term>, PhpException>>()?,
+                .collect::<PhpResult<HashMap<_, _>>>()?,
             None => HashMap::new(),
         };
 
@@ -99,47 +101,42 @@ impl AuthorizerBuilder {
             None => HashMap::new(),
         };
 
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .code_with_params(source, term_params, scope)
-                .map_err(|e| PhpException::from_class::<AuthorizerError>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .code_with_params(source, term_params, scope)
+            .datalog(DatalogKind::Term)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_fact(&mut self, fact: &Fact) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .fact(fact.0.clone())
-                .map_err(|e| PhpException::from_class::<AuthorizerError>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .fact(fact.0.clone())
+            .datalog(DatalogKind::Fact)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_rule(&mut self, rule: &Rule) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .rule(rule.0.clone())
-                .map_err(|e| PhpException::from_class::<AuthorizerError>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .rule(rule.0.clone())
+            .datalog(DatalogKind::Rule)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_check(&mut self, check: &Check) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .check(check.0.clone())
-                .map_err(|e| PhpException::from_class::<AuthorizerError>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .check(check.0.clone())
+            .datalog(DatalogKind::Check)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_policy(&mut self, policy: &Policy) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .policy(policy.0.clone())
-                .map_err(|e| PhpException::from_class::<AuthorizerError>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .policy(policy.0.clone())
+            .datalog(DatalogKind::Policy)?;
+        self.0 = Some(next);
         Ok(())
     }
 
@@ -159,47 +156,47 @@ impl AuthorizerBuilder {
     }
 
     pub fn base64_snapshot(&self) -> PhpResult<String> {
-        get_builder(&self.0)?
+        Ok(get_builder(&self.0)?
             .clone()
             .to_base64_snapshot()
-            .map_err(|e| PhpException::default(format!("Serialization error: {}", e)))
+            .format(FormatKind::Snapshot)?)
     }
 
     pub fn raw_snapshot(&self) -> PhpResult<Vec<u8>> {
-        get_builder(&self.0)?
+        Ok(get_builder(&self.0)?
             .clone()
             .to_raw_snapshot()
-            .map_err(|e| PhpException::default(format!("Serialization error: {}", e)))
+            .format(FormatKind::Snapshot)?)
     }
 
     #[php(name = "fromBase64Snapshot")]
     pub fn from_base64_snapshot(input: &str) -> PhpResult<Self> {
-        biscuit_auth::AuthorizerBuilder::from_base64_snapshot(input)
-            .map(|b| Self(Some(b)))
-            .map_err(|e| PhpException::default(format!("Validation error: {}", e)))
+        let builder = biscuit_auth::AuthorizerBuilder::from_base64_snapshot(input)
+            .format(FormatKind::Snapshot)?;
+        Ok(Self(Some(builder)))
     }
 
     #[php(name = "fromRawSnapshot")]
     pub fn from_raw_snapshot(input: BinarySlice<u8>) -> PhpResult<Self> {
-        biscuit_auth::AuthorizerBuilder::from_raw_snapshot(input.as_ref())
-            .map(|b| Self(Some(b)))
-            .map_err(|e| PhpException::default(format!("Validation error: {}", e)))
+        let builder = biscuit_auth::AuthorizerBuilder::from_raw_snapshot(input.as_ref())
+            .format(FormatKind::Snapshot)?;
+        Ok(Self(Some(builder)))
     }
 
     pub fn build(&self, token: &Biscuit) -> PhpResult<Authorizer> {
-        get_builder(&self.0)?
+        let authorizer = get_builder(&self.0)?
             .clone()
             .build(&token.0)
-            .map(Authorizer)
-            .map_err(|e| PhpException::default(format!("Build error: {}", e)))
+            .build(BuildKind::Authorizer)?;
+        Ok(Authorizer(authorizer))
     }
 
     pub fn build_unauthenticated(&self) -> PhpResult<Authorizer> {
-        get_builder(&self.0)?
+        let authorizer = get_builder(&self.0)?
             .clone()
             .build_unauthenticated()
-            .map(Authorizer)
-            .map_err(|e| PhpException::default(format!("Build error: {}", e)))
+            .build(BuildKind::Authorizer)?;
+        Ok(Authorizer(authorizer))
     }
 
     pub fn __to_string(&self) -> PhpResult<String> {

--- a/src/biscuit.rs
+++ b/src/biscuit.rs
@@ -2,6 +2,7 @@ use ext_php_rs::binary_slice::BinarySlice;
 use ext_php_rs::prelude::*;
 
 use crate::builders::{BiscuitBuilder, BlockBuilder};
+use crate::errors::{BuildKind, FormatKind, ResultExt};
 use crate::helpers::get_builder;
 use crate::keys::PublicKey;
 use crate::third_party::{ThirdPartyBlock, ThirdPartyRequest};
@@ -26,28 +27,24 @@ impl Biscuit {
 
     #[php(name = "fromBytes")]
     pub fn from_bytes(data: BinarySlice<u8>, root: &PublicKey) -> PhpResult<Self> {
-        biscuit_auth::Biscuit::from(data.as_ref(), root.0)
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Biscuit validation error: {}", e)))
+        Ok(Self(
+            biscuit_auth::Biscuit::from(data.as_ref(), root.0).format(FormatKind::Bytes)?,
+        ))
     }
 
     #[php(name = "fromBase64")]
     pub fn from_base64(data: &str, root: &PublicKey) -> PhpResult<Self> {
-        biscuit_auth::Biscuit::from_base64(data, root.0)
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Biscuit validation error: {}", e)))
+        Ok(Self(
+            biscuit_auth::Biscuit::from_base64(data, root.0).format(FormatKind::Base64)?,
+        ))
     }
 
     pub fn to_bytes(&self) -> PhpResult<Vec<u8>> {
-        self.0
-            .to_vec()
-            .map_err(|e| PhpException::default(format!("Serialization error: {}", e)))
+        Ok(self.0.to_vec().format(FormatKind::Bytes)?)
     }
 
     pub fn to_base64(&self) -> PhpResult<String> {
-        self.0
-            .to_base64()
-            .map_err(|e| PhpException::default(format!("Serialization error: {}", e)))
+        Ok(self.0.to_base64().format(FormatKind::Base64)?)
     }
 
     pub fn block_count(&self) -> usize {
@@ -55,16 +52,18 @@ impl Biscuit {
     }
 
     pub fn block_source(&self, index: i64) -> PhpResult<String> {
-        self.0
+        Ok(self
+            .0
             .print_block_source(index as usize)
-            .map_err(|e| PhpException::default(format!("Block error: {}", e)))
+            .format(FormatKind::Snapshot)?)
     }
 
     pub fn append(&self, block: &BlockBuilder) -> PhpResult<Self> {
-        self.0
-            .append(get_builder(&block.0)?.clone())
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Append error: {}", e)))
+        Ok(Self(
+            self.0
+                .append(get_builder(&block.0)?.clone())
+                .build(BuildKind::Append)?,
+        ))
     }
 
     pub fn append_third_party(
@@ -72,17 +71,16 @@ impl Biscuit {
         external_key: &PublicKey,
         block: &ThirdPartyBlock,
     ) -> PhpResult<Self> {
-        self.0
-            .append_third_party(external_key.0, block.0.clone())
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Append third party error: {}", e)))
+        Ok(Self(
+            self.0
+                .append_third_party(external_key.0, block.0.clone())
+                .build(BuildKind::ThirdPartyAppend)?,
+        ))
     }
 
     pub fn third_party_request(&self) -> PhpResult<ThirdPartyRequest> {
-        self.0
-            .third_party_request()
-            .map(|r| ThirdPartyRequest(Some(r)))
-            .map_err(|e| PhpException::default(format!("Third party request error: {}", e)))
+        let request = self.0.third_party_request().third_party()?;
+        Ok(ThirdPartyRequest(Some(request)))
     }
 
     pub fn revocation_ids(&self) -> Vec<String> {
@@ -94,10 +92,11 @@ impl Biscuit {
     }
 
     pub fn block_external_key(&self, index: i64) -> PhpResult<Option<PublicKey>> {
-        self.0
+        let key = self
+            .0
             .block_external_key(index as usize)
-            .map(|opt| opt.map(PublicKey))
-            .map_err(|e| PhpException::default(format!("Block error: {}", e)))
+            .format(FormatKind::Snapshot)?;
+        Ok(key.map(PublicKey))
     }
 
     pub fn __to_string(&self) -> String {
@@ -114,9 +113,9 @@ pub struct UnverifiedBiscuit(biscuit_auth::UnverifiedBiscuit);
 impl UnverifiedBiscuit {
     #[php(name = "fromBase64")]
     pub fn from_base64(data: &str) -> PhpResult<Self> {
-        biscuit_auth::UnverifiedBiscuit::from_base64(data)
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Validation error: {}", e)))
+        Ok(Self(
+            biscuit_auth::UnverifiedBiscuit::from_base64(data).format(FormatKind::Base64)?,
+        ))
     }
 
     pub fn root_key_id(&self) -> Option<u32> {
@@ -128,16 +127,18 @@ impl UnverifiedBiscuit {
     }
 
     pub fn block_source(&self, index: i64) -> PhpResult<String> {
-        self.0
+        Ok(self
+            .0
             .print_block_source(index as usize)
-            .map_err(|e| PhpException::default(format!("Block error: {}", e)))
+            .format(FormatKind::Snapshot)?)
     }
 
     pub fn append(&self, block: &BlockBuilder) -> PhpResult<Self> {
-        self.0
-            .append(get_builder(&block.0)?.clone())
-            .map(Self)
-            .map_err(|e| PhpException::default(format!("Append error: {}", e)))
+        Ok(Self(
+            self.0
+                .append(get_builder(&block.0)?.clone())
+                .build(BuildKind::Append)?,
+        ))
     }
 
     pub fn revocation_ids(&self) -> Vec<String> {
@@ -149,10 +150,11 @@ impl UnverifiedBiscuit {
     }
 
     pub fn verify(&self, root: &PublicKey) -> PhpResult<Biscuit> {
-        self.0
-            .clone()
-            .verify(root.0)
-            .map(Biscuit)
-            .map_err(|e| PhpException::default(format!("Verification error: {}", e)))
+        Ok(Biscuit(
+            self.0
+                .clone()
+                .verify(root.0)
+                .format(FormatKind::Signature)?,
+        ))
     }
 }

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -5,7 +5,7 @@ use ext_php_rs::prelude::*;
 
 use crate::biscuit::Biscuit;
 use crate::datalog::{Check, Fact, Rule};
-use crate::errors::{InvalidCheck, InvalidFact, InvalidRule, InvalidTerm};
+use crate::errors::{BuildKind, DatalogKind, ResultExt};
 use crate::helpers::{MixedValue, get_builder, mixed_value_to_term, take_builder};
 use crate::keys::{PrivateKey, PublicKey};
 
@@ -42,11 +42,11 @@ impl BiscuitBuilder {
 
     pub fn build(&self, root: &PrivateKey) -> PhpResult<Biscuit> {
         let keypair = BiscuitKeyPair::from(&root.0);
-        get_builder(&self.0)?
+        let token = get_builder(&self.0)?
             .clone()
             .build(&keypair)
-            .map(Biscuit::wrap)
-            .map_err(|e| PhpException::default(format!("Build error: {}", e)))
+            .build(BuildKind::Token)?;
+        Ok(Biscuit::wrap(token))
     }
 
     pub fn add_code(
@@ -55,24 +55,13 @@ impl BiscuitBuilder {
         params: Option<HashMap<String, MixedValue>>,
         scope_params: Option<HashMap<String, &PublicKey>>,
     ) -> PhpResult<()> {
-        let term_params: HashMap<String, biscuit_auth::builder::Term> = match params {
-            Some(p) => p
-                .iter()
-                .map(|(k, v)| mixed_value_to_term(v).map(|term| (k.clone(), term)))
-                .collect::<Result<HashMap<String, biscuit_auth::builder::Term>, PhpException>>()?,
-            None => HashMap::new(),
-        };
+        let term_params = collect_term_params(params)?;
+        let scope = collect_scope_params(scope_params);
 
-        let scope: HashMap<String, biscuit_auth::PublicKey> = match scope_params {
-            Some(sp) => sp.iter().map(|(k, v)| (k.clone(), v.0)).collect(),
-            None => HashMap::new(),
-        };
-
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .code_with_params(source, term_params, scope)
-                .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .code_with_params(source, term_params, scope)
+            .datalog(DatalogKind::Term)?;
+        self.0 = Some(next);
         Ok(())
     }
 
@@ -82,29 +71,26 @@ impl BiscuitBuilder {
     }
 
     pub fn add_fact(&mut self, fact: &Fact) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .fact(fact.0.clone())
-                .map_err(|e| PhpException::from_class::<InvalidFact>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .fact(fact.0.clone())
+            .datalog(DatalogKind::Fact)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_rule(&mut self, rule: &Rule) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .rule(rule.0.clone())
-                .map_err(|e| PhpException::from_class::<InvalidRule>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .rule(rule.0.clone())
+            .datalog(DatalogKind::Rule)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_check(&mut self, check: &Check) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .check(check.0.clone())
-                .map_err(|e| PhpException::from_class::<InvalidCheck>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .check(check.0.clone())
+            .datalog(DatalogKind::Check)?;
+        self.0 = Some(next);
         Ok(())
     }
 
@@ -138,29 +124,26 @@ impl BlockBuilder {
     }
 
     pub fn add_fact(&mut self, fact: &Fact) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .fact(fact.0.clone())
-                .map_err(|e| PhpException::from_class::<InvalidFact>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .fact(fact.0.clone())
+            .datalog(DatalogKind::Fact)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_rule(&mut self, rule: &Rule) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .rule(rule.0.clone())
-                .map_err(|e| PhpException::from_class::<InvalidRule>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .rule(rule.0.clone())
+            .datalog(DatalogKind::Rule)?;
+        self.0 = Some(next);
         Ok(())
     }
 
     pub fn add_check(&mut self, check: &Check) -> PhpResult<()> {
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .check(check.0.clone())
-                .map_err(|e| PhpException::from_class::<InvalidCheck>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .check(check.0.clone())
+            .datalog(DatalogKind::Check)?;
+        self.0 = Some(next);
         Ok(())
     }
 
@@ -170,24 +153,13 @@ impl BlockBuilder {
         params: Option<HashMap<String, MixedValue>>,
         scope_params: Option<HashMap<String, &PublicKey>>,
     ) -> PhpResult<()> {
-        let term_params: HashMap<String, biscuit_auth::builder::Term> = match params {
-            Some(p) => p
-                .iter()
-                .map(|(k, v)| mixed_value_to_term(v).map(|term| (k.clone(), term)))
-                .collect::<Result<HashMap<String, biscuit_auth::builder::Term>, PhpException>>()?,
-            None => HashMap::new(),
-        };
+        let term_params = collect_term_params(params)?;
+        let scope = collect_scope_params(scope_params);
 
-        let scope: HashMap<String, biscuit_auth::PublicKey> = match scope_params {
-            Some(sp) => sp.iter().map(|(k, v)| (k.clone(), v.0)).collect(),
-            None => HashMap::new(),
-        };
-
-        self.0 = Some(
-            take_builder(&mut self.0)?
-                .code_with_params(source, term_params, scope)
-                .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))?,
-        );
+        let next = take_builder(&mut self.0)?
+            .code_with_params(source, term_params, scope)
+            .datalog(DatalogKind::Term)?;
+        self.0 = Some(next);
         Ok(())
     }
 
@@ -198,5 +170,26 @@ impl BlockBuilder {
 
     pub fn __to_string(&self) -> PhpResult<String> {
         Ok(format!("{}", get_builder(&self.0)?))
+    }
+}
+
+fn collect_term_params(
+    params: Option<HashMap<String, MixedValue>>,
+) -> PhpResult<HashMap<String, biscuit_auth::builder::Term>> {
+    match params {
+        Some(p) => p
+            .iter()
+            .map(|(k, v)| mixed_value_to_term(v).map(|term| (k.clone(), term)))
+            .collect(),
+        None => Ok(HashMap::new()),
+    }
+}
+
+fn collect_scope_params(
+    scope_params: Option<HashMap<String, &PublicKey>>,
+) -> HashMap<String, biscuit_auth::PublicKey> {
+    match scope_params {
+        Some(sp) => sp.iter().map(|(k, v)| (k.clone(), v.0)).collect(),
+        None => HashMap::new(),
     }
 }

--- a/src/datalog.rs
+++ b/src/datalog.rs
@@ -1,10 +1,39 @@
 use std::collections::HashMap;
 
+use biscuit_parser::error::ParseError as UpstreamParseError;
 use ext_php_rs::prelude::*;
 
-use crate::errors::{InvalidCheck, InvalidFact, InvalidPolicy, InvalidRule, InvalidTerm};
+use crate::errors::{DatalogKind, ResultExt};
 use crate::helpers::{MixedValue, mixed_value_to_term};
 use crate::keys::PublicKey;
+
+#[php_class]
+#[php(name = "Biscuit\\Auth\\ParseError")]
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    input: String,
+    message: Option<String>,
+}
+
+impl ParseError {
+    pub(crate) fn from_upstream(p: &UpstreamParseError) -> Self {
+        Self {
+            input: p.input.clone(),
+            message: p.message.clone(),
+        }
+    }
+}
+
+#[php_impl]
+impl ParseError {
+    pub fn get_input(&self) -> String {
+        self.input.clone()
+    }
+
+    pub fn get_message(&self) -> Option<String> {
+        self.message.clone()
+    }
+}
 
 #[php_class]
 #[php(name = "Biscuit\\Auth\\Rule")]
@@ -18,22 +47,20 @@ impl Rule {
         params: Option<HashMap<String, MixedValue>>,
         scope_params: Option<HashMap<String, &PublicKey>>,
     ) -> PhpResult<Self> {
-        let mut rule: biscuit_auth::builder::Rule = source
-            .try_into()
-            .map_err(|e| PhpException::from_class::<InvalidRule>(format!("{}", e)))?;
+        let mut rule: biscuit_auth::builder::Rule =
+            biscuit_auth::builder::Rule::try_from(source).datalog(DatalogKind::Rule)?;
 
         if let Some(p) = params {
-            p.iter().try_for_each(|(key, value)| {
-                rule.set(key, mixed_value_to_term(value)?)
-                    .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
-            })?;
+            for (key, value) in &p {
+                let term = mixed_value_to_term(value)?;
+                rule.set(key, term).datalog(DatalogKind::Term)?;
+            }
         }
 
         if let Some(sp) = scope_params {
-            sp.iter().try_for_each(|(key, pk)| {
-                rule.set_scope(key, pk.0)
-                    .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
-            })?;
+            for (key, pk) in &sp {
+                rule.set_scope(key, pk.0).datalog(DatalogKind::Scope)?;
+            }
         }
 
         Ok(Self(rule))
@@ -42,16 +69,13 @@ impl Rule {
     /// @param int|string|bool|null $value
     pub fn set(&mut self, name: &str, value: MixedValue) -> PhpResult<()> {
         let term_value = mixed_value_to_term(&value)?;
-
-        self.0
-            .set(name, term_value)
-            .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
+        self.0.set(name, term_value).datalog(DatalogKind::Term)?;
+        Ok(())
     }
 
     pub fn set_scope(&mut self, name: &str, key: &PublicKey) -> PhpResult<()> {
-        self.0
-            .set_scope(name, key.0)
-            .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
+        self.0.set_scope(name, key.0).datalog(DatalogKind::Scope)?;
+        Ok(())
     }
 
     pub fn __to_string(&self) -> String {
@@ -70,15 +94,14 @@ impl Fact {
         source: &str,
         params: Option<HashMap<String, MixedValue>>,
     ) -> PhpResult<Self> {
-        let mut fact: biscuit_auth::builder::Fact = source
-            .try_into()
-            .map_err(|e| PhpException::from_class::<InvalidFact>(format!("{}", e)))?;
+        let mut fact: biscuit_auth::builder::Fact =
+            biscuit_auth::builder::Fact::try_from(source).datalog(DatalogKind::Fact)?;
 
         if let Some(p) = params {
-            p.iter().try_for_each(|(key, value)| {
-                fact.set(key, mixed_value_to_term(value)?)
-                    .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
-            })?;
+            for (key, value) in &p {
+                let term = mixed_value_to_term(value)?;
+                fact.set(key, term).datalog(DatalogKind::Term)?;
+            }
         }
 
         Ok(Self(fact))
@@ -87,10 +110,8 @@ impl Fact {
     /// @param int|string|bool|null $value
     pub fn set(&mut self, name: &str, value: MixedValue) -> PhpResult<()> {
         let term_value = mixed_value_to_term(&value)?;
-
-        self.0
-            .set(name, term_value)
-            .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
+        self.0.set(name, term_value).datalog(DatalogKind::Term)?;
+        Ok(())
     }
 
     pub fn name(&self) -> String {
@@ -114,24 +135,20 @@ impl Check {
         params: Option<HashMap<String, MixedValue>>,
         scope_params: Option<HashMap<String, &PublicKey>>,
     ) -> PhpResult<Self> {
-        let mut check: biscuit_auth::builder::Check = source
-            .try_into()
-            .map_err(|e| PhpException::from_class::<InvalidCheck>(format!("{}", e)))?;
+        let mut check: biscuit_auth::builder::Check =
+            biscuit_auth::builder::Check::try_from(source).datalog(DatalogKind::Check)?;
 
         if let Some(p) = params {
-            p.iter().try_for_each(|(key, value)| {
-                check
-                    .set(key, mixed_value_to_term(value)?)
-                    .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
-            })?;
+            for (key, value) in &p {
+                let term = mixed_value_to_term(value)?;
+                check.set(key, term).datalog(DatalogKind::Term)?;
+            }
         }
 
         if let Some(sp) = scope_params {
-            sp.iter().try_for_each(|(key, pk)| {
-                check
-                    .set_scope(key, pk.0)
-                    .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
-            })?;
+            for (key, pk) in &sp {
+                check.set_scope(key, pk.0).datalog(DatalogKind::Scope)?;
+            }
         }
 
         Ok(Self(check))
@@ -140,16 +157,13 @@ impl Check {
     /// @param int|string|bool|null $value
     pub fn set(&mut self, name: &str, value: MixedValue) -> PhpResult<()> {
         let term_value = mixed_value_to_term(&value)?;
-
-        self.0
-            .set(name, term_value)
-            .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
+        self.0.set(name, term_value).datalog(DatalogKind::Term)?;
+        Ok(())
     }
 
     pub fn set_scope(&mut self, name: &str, key: &PublicKey) -> PhpResult<()> {
-        self.0
-            .set_scope(name, key.0)
-            .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
+        self.0.set_scope(name, key.0).datalog(DatalogKind::Scope)?;
+        Ok(())
     }
 
     pub fn __to_string(&self) -> String {
@@ -169,24 +183,20 @@ impl Policy {
         params: Option<HashMap<String, MixedValue>>,
         scope_params: Option<HashMap<String, &PublicKey>>,
     ) -> PhpResult<Self> {
-        let mut policy: biscuit_auth::builder::Policy = source
-            .try_into()
-            .map_err(|e| PhpException::from_class::<InvalidPolicy>(format!("{}", e)))?;
+        let mut policy: biscuit_auth::builder::Policy =
+            biscuit_auth::builder::Policy::try_from(source).datalog(DatalogKind::Policy)?;
 
         if let Some(p) = params {
-            p.iter().try_for_each(|(key, value)| {
-                policy
-                    .set(key, mixed_value_to_term(value)?)
-                    .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
-            })?;
+            for (key, value) in &p {
+                let term = mixed_value_to_term(value)?;
+                policy.set(key, term).datalog(DatalogKind::Term)?;
+            }
         }
 
         if let Some(sp) = scope_params {
-            sp.iter().try_for_each(|(key, pk)| {
-                policy
-                    .set_scope(key, pk.0)
-                    .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
-            })?;
+            for (key, pk) in &sp {
+                policy.set_scope(key, pk.0).datalog(DatalogKind::Scope)?;
+            }
         }
 
         Ok(Self(policy))
@@ -195,16 +205,13 @@ impl Policy {
     /// @param int|string|bool|null $value
     pub fn set(&mut self, name: &str, value: MixedValue) -> PhpResult<()> {
         let term_value = mixed_value_to_term(&value)?;
-
-        self.0
-            .set(name, term_value)
-            .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
+        self.0.set(name, term_value).datalog(DatalogKind::Term)?;
+        Ok(())
     }
 
     pub fn set_scope(&mut self, name: &str, key: &PublicKey) -> PhpResult<()> {
-        self.0
-            .set_scope(name, key.0)
-            .map_err(|e| PhpException::from_class::<InvalidTerm>(e.to_string()))
+        self.0.set_scope(name, key.0).datalog(DatalogKind::Scope)?;
+        Ok(())
     }
 
     pub fn __to_string(&self) -> String {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,62 +1,551 @@
+use biscuit_auth::error::{Logic, Token};
+use biscuit_parser::error::LanguageError;
+use ext_php_rs::class::RegisteredClass;
+use ext_php_rs::convert::IntoZval;
+use ext_php_rs::ffi::{zend_class_entry, zend_object};
 use ext_php_rs::prelude::*;
+use ext_php_rs::types::{ZendClassObject, Zval};
 use ext_php_rs::zend::ce;
+use std::os::raw::c_char;
+use thiserror::Error;
+
+use crate::authorization::{AuthorizationException, FailedCheck, MatchedPolicy};
+use crate::datalog::ParseError;
+
+// SAFETY: `zend_update_property_stringl` is a standard ZEND_API function exported
+// by libphp; safe to call during PHP request execution.
+unsafe extern "C" {
+    fn zend_update_property_stringl(
+        scope: *mut zend_class_entry,
+        object: *mut zend_object,
+        name: *const c_char,
+        name_length: usize,
+        value: *const c_char,
+        value_len: usize,
+    );
+}
+
+fn populate_exception_message(zval: &mut Zval, message: &str) {
+    let Some(obj) = zval.object_mut() else {
+        return;
+    };
+    unsafe {
+        zend_update_property_stringl(
+            std::ptr::from_ref(ce::exception()).cast_mut(),
+            std::ptr::from_mut::<ext_php_rs::types::ZendObject>(obj),
+            b"message".as_ptr().cast::<c_char>(),
+            7,
+            message.as_ptr().cast::<c_char>(),
+            message.len(),
+        );
+    }
+}
+
+type BoxedError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub(crate) enum KeyKind {
+    PublicKey = 1,
+    PrivateKey = 2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub(crate) enum DatalogKind {
+    Fact = 1,
+    Rule = 2,
+    Check = 3,
+    Policy = 4,
+    Term = 5,
+    Scope = 6,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub(crate) enum FormatKind {
+    Base64 = 1,
+    Bytes = 2,
+    Signature = 3,
+    Snapshot = 4,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub(crate) enum BuildKind {
+    Token = 1,
+    Append = 2,
+    Authorizer = 3,
+    ThirdPartyAppend = 4,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum BiscuitError {
+    #[error("{source}")]
+    Key {
+        kind: KeyKind,
+        #[source]
+        source: BoxedError,
+    },
+    #[error("{source}")]
+    Datalog {
+        kind: DatalogKind,
+        #[source]
+        source: BoxedError,
+    },
+    #[error("{source}")]
+    Format {
+        kind: FormatKind,
+        #[source]
+        source: BoxedError,
+    },
+    #[error("{source}")]
+    Build {
+        kind: BuildKind,
+        #[source]
+        source: BoxedError,
+    },
+    #[error("authorization failed: {source}")]
+    Authorization {
+        #[source]
+        source: biscuit_auth::error::Token,
+        policies: Vec<biscuit_auth::builder::Policy>,
+    },
+    #[error("{source}")]
+    ThirdParty {
+        #[source]
+        source: BoxedError,
+    },
+    #[error("{0}")]
+    BuilderConsumed(&'static str),
+}
+
+#[derive(Debug, Error)]
+#[error("{0}")]
+pub(crate) struct StaticError(pub(crate) &'static str);
+
+impl BiscuitError {
+    pub(crate) fn authorization(
+        source: biscuit_auth::error::Token,
+        policies: Vec<biscuit_auth::builder::Policy>,
+    ) -> Self {
+        Self::Authorization { source, policies }
+    }
+}
+
+pub(crate) trait ResultExt<T> {
+    fn key(self, kind: KeyKind) -> Result<T, BiscuitError>;
+    fn datalog(self, kind: DatalogKind) -> Result<T, BiscuitError>;
+    fn format(self, kind: FormatKind) -> Result<T, BiscuitError>;
+    fn build(self, kind: BuildKind) -> Result<T, BiscuitError>;
+    fn third_party(self) -> Result<T, BiscuitError>;
+}
+
+impl<T, E> ResultExt<T> for Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn key(self, kind: KeyKind) -> Result<T, BiscuitError> {
+        self.map_err(|source| BiscuitError::Key {
+            kind,
+            source: Box::new(source),
+        })
+    }
+
+    fn datalog(self, kind: DatalogKind) -> Result<T, BiscuitError> {
+        self.map_err(|source| BiscuitError::Datalog {
+            kind,
+            source: Box::new(source),
+        })
+    }
+
+    fn format(self, kind: FormatKind) -> Result<T, BiscuitError> {
+        self.map_err(|source| BiscuitError::Format {
+            kind,
+            source: Box::new(source),
+        })
+    }
+
+    fn build(self, kind: BuildKind) -> Result<T, BiscuitError> {
+        self.map_err(|source| BiscuitError::Build {
+            kind,
+            source: Box::new(source),
+        })
+    }
+
+    fn third_party(self) -> Result<T, BiscuitError> {
+        self.map_err(|source| BiscuitError::ThirdParty {
+            source: Box::new(source),
+        })
+    }
+}
+
+pub(crate) fn collect_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut parts: Vec<String> = vec![err.to_string()];
+    let mut current = err.source();
+    while let Some(src) = current {
+        let part = src.to_string();
+        if parts.last() != Some(&part) {
+            parts.push(part);
+        }
+        current = src.source();
+    }
+    parts.join(": ")
+}
 
 #[php_class]
-#[php(name = "Biscuit\\Exception\\InvalidPrivateKey")]
+#[php(name = "Biscuit\\Exception\\BiscuitException")]
 #[php(extends(ce = ce::exception, stub = "\\Exception"))]
 #[derive(Default, Clone)]
-pub struct InvalidPrivateKey;
+pub struct BiscuitException;
 
 #[php_class]
-#[php(name = "Biscuit\\Exception\\InvalidPublicKey")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[php(name = "Biscuit\\Exception\\KeyException")]
+#[php(extends(BiscuitException))]
 #[derive(Default, Clone)]
-pub struct InvalidPublicKey;
+pub struct KeyException;
+
+macro_rules! marker_subclass {
+    ($struct_name:ident, $php_name:literal, $parent:ident) => {
+        #[php_class]
+        #[php(name = $php_name)]
+        #[php(extends($parent))]
+        #[derive(Default, Clone)]
+        pub struct $struct_name;
+    };
+}
+
+marker_subclass!(
+    PublicKeyException,
+    "Biscuit\\Exception\\PublicKeyException",
+    KeyException
+);
+marker_subclass!(
+    PrivateKeyException,
+    "Biscuit\\Exception\\PrivateKeyException",
+    KeyException
+);
 
 #[php_class]
-#[php(name = "Biscuit\\Exception\\InvalidCheck")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
-#[derive(Default, Clone)]
-pub struct InvalidCheck;
+#[php(name = "Biscuit\\Exception\\DatalogException")]
+#[php(extends(BiscuitException))]
+#[derive(Debug, Default, Clone)]
+pub struct DatalogException;
+
+#[php_impl]
+impl DatalogException {
+    pub fn get_parse_errors(&self) -> Option<Vec<ParseError>> {
+        None
+    }
+
+    pub fn get_missing_parameters(&self) -> Option<Vec<String>> {
+        None
+    }
+
+    pub fn get_unused_parameters(&self) -> Option<Vec<String>> {
+        None
+    }
+}
+
+macro_rules! datalog_subclass {
+    ($struct_name:ident, $php_name:literal) => {
+        #[php_class]
+        #[php(name = $php_name)]
+        #[php(extends(DatalogException))]
+        #[derive(Debug, Default, Clone)]
+        pub struct $struct_name {
+            parse_errors: Option<Vec<ParseError>>,
+            missing_parameters: Option<Vec<String>>,
+            unused_parameters: Option<Vec<String>>,
+        }
+
+        impl $struct_name {
+            pub(crate) fn new(
+                parse_errors: Option<Vec<ParseError>>,
+                missing_parameters: Option<Vec<String>>,
+                unused_parameters: Option<Vec<String>>,
+            ) -> Self {
+                Self {
+                    parse_errors,
+                    missing_parameters,
+                    unused_parameters,
+                }
+            }
+        }
+
+        #[php_impl]
+        impl $struct_name {
+            pub fn get_parse_errors(&self) -> Option<Vec<ParseError>> {
+                self.parse_errors.clone()
+            }
+
+            pub fn get_missing_parameters(&self) -> Option<Vec<String>> {
+                self.missing_parameters.clone()
+            }
+
+            pub fn get_unused_parameters(&self) -> Option<Vec<String>> {
+                self.unused_parameters.clone()
+            }
+        }
+    };
+}
+
+datalog_subclass!(FactException, "Biscuit\\Exception\\FactException");
+datalog_subclass!(RuleException, "Biscuit\\Exception\\RuleException");
+datalog_subclass!(CheckException, "Biscuit\\Exception\\CheckException");
+datalog_subclass!(PolicyException, "Biscuit\\Exception\\PolicyException");
+datalog_subclass!(TermException, "Biscuit\\Exception\\TermException");
+datalog_subclass!(ScopeException, "Biscuit\\Exception\\ScopeException");
 
 #[php_class]
-#[php(name = "Biscuit\\Exception\\InvalidPolicy")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[php(name = "Biscuit\\Exception\\FormatException")]
+#[php(extends(BiscuitException))]
 #[derive(Default, Clone)]
-pub struct InvalidPolicy;
+pub struct FormatException;
+
+marker_subclass!(
+    Base64Exception,
+    "Biscuit\\Exception\\Base64Exception",
+    FormatException
+);
+marker_subclass!(
+    BytesException,
+    "Biscuit\\Exception\\BytesException",
+    FormatException
+);
+marker_subclass!(
+    SignatureException,
+    "Biscuit\\Exception\\SignatureException",
+    FormatException
+);
+marker_subclass!(
+    SnapshotException,
+    "Biscuit\\Exception\\SnapshotException",
+    FormatException
+);
 
 #[php_class]
-#[php(name = "Biscuit\\Exception\\InvalidFact")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[php(name = "Biscuit\\Exception\\BuildException")]
+#[php(extends(BiscuitException))]
 #[derive(Default, Clone)]
-pub struct InvalidFact;
+pub struct BuildException;
+
+marker_subclass!(
+    BiscuitBuildException,
+    "Biscuit\\Exception\\BiscuitBuildException",
+    BuildException
+);
+marker_subclass!(
+    BlockAppendException,
+    "Biscuit\\Exception\\BlockAppendException",
+    BuildException
+);
+marker_subclass!(
+    AuthorizerBuildException,
+    "Biscuit\\Exception\\AuthorizerBuildException",
+    BuildException
+);
+marker_subclass!(
+    ThirdPartyBlockAppendException,
+    "Biscuit\\Exception\\ThirdPartyBlockAppendException",
+    BuildException
+);
 
 #[php_class]
-#[php(name = "Biscuit\\Exception\\InvalidRule")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[php(name = "Biscuit\\Exception\\BuilderStateException")]
+#[php(extends(BiscuitException))]
 #[derive(Default, Clone)]
-pub struct InvalidRule;
+pub struct BuilderStateException;
 
 #[php_class]
-#[php(name = "Biscuit\\Exception\\InvalidTerm")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
+#[php(name = "Biscuit\\Exception\\ThirdPartyException")]
+#[php(extends(BiscuitException))]
 #[derive(Default, Clone)]
-pub struct InvalidTerm;
+pub struct ThirdPartyException;
 
-#[php_class]
-#[php(name = "Biscuit\\Exception\\ThirdPartyRequestError")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
-#[derive(Default, Clone)]
-pub struct ThirdPartyRequestError;
+impl From<BiscuitError> for PhpException {
+    fn from(err: BiscuitError) -> Self {
+        let message = collect_chain(&err);
+        match err {
+            BiscuitError::Key { kind, .. } => match kind {
+                KeyKind::PublicKey => PhpException::from_class::<PublicKeyException>(message),
+                KeyKind::PrivateKey => PhpException::from_class::<PrivateKeyException>(message),
+            },
+            BiscuitError::Datalog { kind, source } => {
+                build_datalog_exception(kind, &*source, message)
+            }
+            BiscuitError::Format { kind, .. } => match kind {
+                FormatKind::Base64 => PhpException::from_class::<Base64Exception>(message),
+                FormatKind::Bytes => PhpException::from_class::<BytesException>(message),
+                FormatKind::Signature => PhpException::from_class::<SignatureException>(message),
+                FormatKind::Snapshot => PhpException::from_class::<SnapshotException>(message),
+            },
+            BiscuitError::Build { kind, .. } => match kind {
+                BuildKind::Token => PhpException::from_class::<BiscuitBuildException>(message),
+                BuildKind::Append => PhpException::from_class::<BlockAppendException>(message),
+                BuildKind::Authorizer => {
+                    PhpException::from_class::<AuthorizerBuildException>(message)
+                }
+                BuildKind::ThirdPartyAppend => {
+                    PhpException::from_class::<ThirdPartyBlockAppendException>(message)
+                }
+            },
+            BiscuitError::ThirdParty { .. } => {
+                PhpException::from_class::<ThirdPartyException>(message)
+            }
+            BiscuitError::BuilderConsumed(_) => {
+                PhpException::from_class::<BuilderStateException>(message)
+            }
+            BiscuitError::Authorization { source, policies } => {
+                build_authorization_exception(&source, &policies, message)
+            }
+        }
+    }
+}
 
-#[php_class]
-#[php(name = "Biscuit\\Exception\\AuthorizerError")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
-#[derive(Default, Clone)]
-pub struct AuthorizerError;
+#[derive(Default)]
+struct DatalogPayload {
+    parse_errors: Option<Vec<ParseError>>,
+    missing_parameters: Option<Vec<String>>,
+    unused_parameters: Option<Vec<String>>,
+}
 
-#[php_class]
-#[php(name = "Biscuit\\Exception\\BuilderConsumed")]
-#[php(extends(ce = ce::exception, stub = "\\Exception"))]
-#[derive(Default, Clone)]
-pub struct BuilderConsumed;
+fn build_datalog_exception(
+    kind: DatalogKind,
+    source: &(dyn std::error::Error + 'static),
+    message: String,
+) -> PhpException {
+    let payload = classify_datalog(source);
+
+    match kind {
+        DatalogKind::Fact => into_php_exception(
+            FactException::new(
+                payload.parse_errors,
+                payload.missing_parameters,
+                payload.unused_parameters,
+            ),
+            message,
+        ),
+        DatalogKind::Rule => into_php_exception(
+            RuleException::new(
+                payload.parse_errors,
+                payload.missing_parameters,
+                payload.unused_parameters,
+            ),
+            message,
+        ),
+        DatalogKind::Check => into_php_exception(
+            CheckException::new(
+                payload.parse_errors,
+                payload.missing_parameters,
+                payload.unused_parameters,
+            ),
+            message,
+        ),
+        DatalogKind::Policy => into_php_exception(
+            PolicyException::new(
+                payload.parse_errors,
+                payload.missing_parameters,
+                payload.unused_parameters,
+            ),
+            message,
+        ),
+        DatalogKind::Term => into_php_exception(
+            TermException::new(
+                payload.parse_errors,
+                payload.missing_parameters,
+                payload.unused_parameters,
+            ),
+            message,
+        ),
+        DatalogKind::Scope => into_php_exception(
+            ScopeException::new(
+                payload.parse_errors,
+                payload.missing_parameters,
+                payload.unused_parameters,
+            ),
+            message,
+        ),
+    }
+}
+
+fn into_php_exception<T>(value: T, message: String) -> PhpException
+where
+    T: IntoZval + RegisteredClass,
+{
+    match ZendClassObject::new(value).into_zval(false) {
+        Ok(mut zval) => {
+            populate_exception_message(&mut zval, &message);
+            PhpException::default(message).with_object(zval)
+        }
+        Err(_) => PhpException::from_class::<T>(message),
+    }
+}
+
+fn classify_datalog(source: &(dyn std::error::Error + 'static)) -> DatalogPayload {
+    match find_language_error(source) {
+        Some(LanguageError::ParseError(parse_errors)) => DatalogPayload {
+            parse_errors: Some(
+                parse_errors
+                    .errors
+                    .iter()
+                    .map(ParseError::from_upstream)
+                    .collect(),
+            ),
+            ..DatalogPayload::default()
+        },
+        Some(LanguageError::Parameters {
+            missing_parameters,
+            unused_parameters,
+        }) => DatalogPayload {
+            missing_parameters: Some(missing_parameters.clone()),
+            unused_parameters: Some(unused_parameters.clone()),
+            ..DatalogPayload::default()
+        },
+        None => DatalogPayload::default(),
+    }
+}
+
+fn find_language_error<'a>(
+    err: &'a (dyn std::error::Error + 'static),
+) -> Option<&'a LanguageError> {
+    let mut current: Option<&'a (dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = current {
+        if let Some(le) = e.downcast_ref::<LanguageError>() {
+            return Some(le);
+        }
+        if let Some(Token::Language(le)) = e.downcast_ref::<Token>() {
+            return Some(le);
+        }
+        current = e.source();
+    }
+    None
+}
+
+fn build_authorization_exception(
+    error: &Token,
+    policies: &[biscuit_auth::builder::Policy],
+    message: String,
+) -> PhpException {
+    let (matched_policy, failed_checks) = match error {
+        Token::FailedLogic(Logic::Unauthorized { policy, checks }) => (
+            Some(MatchedPolicy::from_upstream(policy, policies)),
+            checks.iter().map(FailedCheck::from_upstream).collect(),
+        ),
+        Token::FailedLogic(Logic::NoMatchingPolicy { checks }) => (
+            None,
+            checks.iter().map(FailedCheck::from_upstream).collect(),
+        ),
+        _ => (None, Vec::new()),
+    };
+
+    let payload = AuthorizationException::new(matched_policy, failed_checks);
+
+    match ZendClassObject::new(payload).into_zval(false) {
+        Ok(mut zval) => {
+            populate_exception_message(&mut zval, &message);
+            PhpException::default(message).with_object(zval)
+        }
+        Err(_) => PhpException::from_class::<AuthorizationException>(message),
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,6 @@
 use ext_php_rs::prelude::*;
 
-use crate::errors::{BuilderConsumed, InvalidTerm};
+use crate::errors::{BiscuitError, DatalogKind, ResultExt, StaticError};
 
 #[derive(Debug, ZvalConvert)]
 pub enum MixedValue {
@@ -23,20 +23,18 @@ pub fn mixed_value_to_term(value: &MixedValue) -> PhpResult<biscuit_auth::builde
             let term_set: std::collections::BTreeSet<_> = terms?.into_iter().collect();
             Ok(biscuit_auth::builder::Term::Set(term_set))
         }
-        MixedValue::None => Err(PhpException::from_class::<InvalidTerm>(
-            "unexpected value".to_string(),
-        )),
+        MixedValue::None => {
+            Err::<_, StaticError>(StaticError("unexpected value")).datalog(DatalogKind::Term)?
+        }
     }
 }
 
 pub fn take_builder<T>(opt: &mut Option<T>) -> PhpResult<T> {
-    opt.take().ok_or_else(|| {
-        PhpException::from_class::<BuilderConsumed>("Builder has already been consumed".to_string())
-    })
+    opt.take()
+        .ok_or_else(|| BiscuitError::BuilderConsumed("builder has already been consumed").into())
 }
 
 pub fn get_builder<T>(opt: &Option<T>) -> PhpResult<&T> {
-    opt.as_ref().ok_or_else(|| {
-        PhpException::from_class::<BuilderConsumed>("Builder has already been consumed".to_string())
-    })
+    opt.as_ref()
+        .ok_or_else(|| BiscuitError::BuilderConsumed("builder has already been consumed").into())
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -5,7 +5,7 @@ use biscuit_auth::builder::Algorithm as BiscuitAlgorithm;
 use ext_php_rs::binary_slice::BinarySlice;
 use ext_php_rs::prelude::*;
 
-use crate::errors::{InvalidPrivateKey, InvalidPublicKey};
+use crate::errors::{KeyKind, ResultExt};
 
 #[php_enum]
 #[php(name = "Biscuit\\Auth\\Algorithm")]
@@ -61,31 +61,32 @@ pub struct PublicKey(pub(crate) biscuit_auth::PublicKey);
 #[php_impl]
 impl PublicKey {
     pub fn __construct(data: &str) -> PhpResult<Self> {
-        biscuit_auth::PublicKey::from_str(data)
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPublicKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PublicKey::from_str(data).key(KeyKind::PublicKey)?,
+        ))
     }
 
     #[php(name = "fromBytes")]
     pub fn from_bytes(data: BinarySlice<u8>, alg: Option<Algorithm>) -> PhpResult<Self> {
         let algorithm = alg.unwrap_or(Algorithm::Ed25519).into();
-        biscuit_auth::PublicKey::from_bytes(data.as_ref(), algorithm)
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPublicKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PublicKey::from_bytes(data.as_ref(), algorithm)
+                .key(KeyKind::PublicKey)?,
+        ))
     }
 
     #[php(name = "fromPem")]
     pub fn from_pem(pem: &str) -> PhpResult<Self> {
-        biscuit_auth::PublicKey::from_pem(pem)
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPublicKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PublicKey::from_pem(pem).key(KeyKind::PublicKey)?,
+        ))
     }
 
     #[php(name = "fromDer")]
     pub fn from_der(der: BinarySlice<u8>) -> PhpResult<Self> {
-        biscuit_auth::PublicKey::from_der(der.as_ref())
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPublicKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PublicKey::from_der(der.as_ref()).key(KeyKind::PublicKey)?,
+        ))
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -109,31 +110,32 @@ pub struct PrivateKey(pub(crate) biscuit_auth::PrivateKey);
 #[php_impl]
 impl PrivateKey {
     pub fn __construct(data: &str) -> PhpResult<Self> {
-        biscuit_auth::PrivateKey::from_str(data)
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPrivateKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PrivateKey::from_str(data).key(KeyKind::PrivateKey)?,
+        ))
     }
 
     #[php(name = "fromBytes")]
     pub fn from_bytes(data: BinarySlice<u8>, alg: Option<Algorithm>) -> PhpResult<Self> {
         let algorithm = alg.unwrap_or(Algorithm::Ed25519).into();
-        biscuit_auth::PrivateKey::from_bytes(data.as_ref(), algorithm)
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPrivateKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PrivateKey::from_bytes(data.as_ref(), algorithm)
+                .key(KeyKind::PrivateKey)?,
+        ))
     }
 
     #[php(name = "fromPem")]
     pub fn from_pem(pem: &str) -> PhpResult<Self> {
-        biscuit_auth::PrivateKey::from_pem(pem)
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPrivateKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PrivateKey::from_pem(pem).key(KeyKind::PrivateKey)?,
+        ))
     }
 
     #[php(name = "fromDer")]
     pub fn from_der(der: BinarySlice<u8>) -> PhpResult<Self> {
-        biscuit_auth::PrivateKey::from_der(der.as_ref())
-            .map(Self)
-            .map_err(|e| PhpException::from_class::<InvalidPrivateKey>(e.to_string()))
+        Ok(Self(
+            biscuit_auth::PrivateKey::from_der(der.as_ref()).key(KeyKind::PrivateKey)?,
+        ))
     }
 
     pub fn generate(alg: Option<Algorithm>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(windows, feature(abi_vectorcall))]
 
+mod authorization;
 mod authorizer;
 mod biscuit;
 mod builders;
@@ -9,6 +10,7 @@ mod helpers;
 mod keys;
 mod third_party;
 
+pub use authorization::*;
 pub use authorizer::*;
 pub use biscuit::*;
 pub use builders::*;
@@ -51,17 +53,34 @@ pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
         .class::<Fact>()
         .class::<Check>()
         .class::<Policy>()
+        .class::<ParseError>()
         .class::<KeyPair>()
         .class::<PublicKey>()
         .class::<PrivateKey>()
-        .class::<InvalidPrivateKey>()
-        .class::<InvalidPublicKey>()
-        .class::<InvalidCheck>()
-        .class::<InvalidPolicy>()
-        .class::<InvalidFact>()
-        .class::<InvalidRule>()
-        .class::<InvalidTerm>()
-        .class::<ThirdPartyRequestError>()
-        .class::<AuthorizerError>()
-        .class::<BuilderConsumed>()
+        .class::<BiscuitException>()
+        .class::<KeyException>()
+        .class::<PublicKeyException>()
+        .class::<PrivateKeyException>()
+        .class::<DatalogException>()
+        .class::<FactException>()
+        .class::<RuleException>()
+        .class::<CheckException>()
+        .class::<PolicyException>()
+        .class::<TermException>()
+        .class::<ScopeException>()
+        .class::<FormatException>()
+        .class::<Base64Exception>()
+        .class::<BytesException>()
+        .class::<SignatureException>()
+        .class::<SnapshotException>()
+        .class::<BuildException>()
+        .class::<BiscuitBuildException>()
+        .class::<BlockAppendException>()
+        .class::<AuthorizerBuildException>()
+        .class::<ThirdPartyBlockAppendException>()
+        .class::<BuilderStateException>()
+        .class::<ThirdPartyException>()
+        .class::<MatchedPolicy>()
+        .class::<FailedCheck>()
+        .class::<AuthorizationException>()
 }

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -2,7 +2,7 @@ use biscuit_auth::ThirdPartyBlock as BiscuitThirdPartyBlock;
 use ext_php_rs::prelude::*;
 
 use crate::builders::BlockBuilder;
-use crate::errors::ThirdPartyRequestError;
+use crate::errors::{BiscuitError, ResultExt};
 use crate::helpers::get_builder;
 use crate::keys::PrivateKey;
 
@@ -18,15 +18,15 @@ impl ThirdPartyRequest {
         block: &BlockBuilder,
     ) -> PhpResult<ThirdPartyBlock> {
         let request = self.0.take().ok_or_else(|| {
-            PhpException::from_class::<ThirdPartyRequestError>(
-                "ThirdPartyRequest already consumed".to_string(),
-            )
+            PhpException::from(BiscuitError::BuilderConsumed(
+                "third-party request has already been consumed",
+            ))
         })?;
 
-        request
+        let signed = request
             .create_block(&private_key.0, get_builder(&block.0)?.clone())
-            .map(ThirdPartyBlock)
-            .map_err(|e| PhpException::from_class::<ThirdPartyRequestError>(e.to_string()))
+            .third_party()?;
+        Ok(ThirdPartyBlock(signed))
     }
 }
 

--- a/tests/BiscuitTest.php
+++ b/tests/BiscuitTest.php
@@ -12,6 +12,7 @@ use Biscuit\Auth\BlockBuilder;
 use Biscuit\Auth\Check;
 use Biscuit\Auth\Fact;
 use Biscuit\Auth\KeyPair;
+use Biscuit\Auth\MatchedPolicy;
 use Biscuit\Auth\Policy;
 use Biscuit\Auth\PrivateKey;
 use Biscuit\Auth\PublicKey;
@@ -19,7 +20,8 @@ use Biscuit\Auth\Rule;
 use Biscuit\Auth\ThirdPartyBlock;
 use Biscuit\Auth\ThirdPartyRequest;
 use Biscuit\Auth\UnverifiedBiscuit;
-use Biscuit\Exception\BuilderConsumed;
+use Biscuit\Exception\BuilderStateException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class BiscuitTest extends TestCase
@@ -156,7 +158,9 @@ class BiscuitTest extends TestCase
         $authBuilder = new AuthorizerBuilder('allow if true');
         $authorizer = $authBuilder->buildUnauthenticated();
         $policy = $authorizer->authorize();
-        static::assertSame(0, $policy);
+        static::assertInstanceOf(MatchedPolicy::class, $policy);
+        static::assertSame(0, $policy->getPolicyId());
+        static::assertSame('allow', $policy->getKind());
     }
 
     public function testBiscuitSerialization(): void
@@ -259,7 +263,7 @@ class BiscuitTest extends TestCase
         static::assertInstanceOf(Authorizer::class, $authorizer);
 
         $policy = $authorizer->authorize();
-        static::assertSame(0, $policy);
+        static::assertSame(0, $policy->getPolicyId());
     }
 
     public function testCompleteLifecycle(): void
@@ -289,7 +293,8 @@ class BiscuitTest extends TestCase
         $authorizer = $authBuilder->build($parsedToken);
 
         $policy = $authorizer->authorize();
-        static::assertSame(0, $policy);
+        static::assertSame(0, $policy->getPolicyId());
+        static::assertStringContainsString('allow if user("1234")', (string) $policy->getCode());
     }
 
     public function testAuthorizerQuery(): void
@@ -333,7 +338,7 @@ class BiscuitTest extends TestCase
         static::assertInstanceOf(Authorizer::class, $parsed);
 
         $policy = $parsed->authorize();
-        static::assertSame(0, $policy);
+        static::assertSame(0, $policy->getPolicyId());
 
         $rawSnapshot = $authorizer->rawSnapshot();
         static::assertIsArray($rawSnapshot);
@@ -342,7 +347,7 @@ class BiscuitTest extends TestCase
         static::assertInstanceOf(Authorizer::class, $parsedFromRaw);
 
         $rawPolicy = $parsedFromRaw->authorize();
-        static::assertSame(0, $rawPolicy);
+        static::assertSame(0, $rawPolicy->getPolicyId());
     }
 
     public function testAuthorizerBuilderSnapshot(): void
@@ -675,10 +680,9 @@ class BiscuitTest extends TestCase
         static::assertInstanceOf(Authorizer::class, $authorizer2);
     }
 
-    public function testBlockBuilderConsumedAfterMerge(): void
+    #[Test]
+    public function blockBuilderConsumedAfterMerge(): void
     {
-        $kp = new KeyPair();
-
         $authBuilder = new AuthorizerBuilder();
         $authBuilder->addCode('user("alice")');
 
@@ -687,7 +691,9 @@ class BiscuitTest extends TestCase
 
         $authBuilder->mergeBlock($blockBuilder);
 
-        $this->expectException(BuilderConsumed::class);
+        $this->expectException(BuilderStateException::class);
+        $this->expectExceptionMessage('builder has already been consumed');
+
         $blockBuilder->addCode('resource("file2")');
     }
 }

--- a/tests/BuildExceptionTest.php
+++ b/tests/BuildExceptionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Biscuit\Tests;
+
+use Biscuit\Exception\AuthorizerBuildException;
+use Biscuit\Exception\BiscuitBuildException;
+use Biscuit\Exception\BiscuitException;
+use Biscuit\Exception\BlockAppendException;
+use Biscuit\Exception\BuildException;
+use Biscuit\Exception\ThirdPartyBlockAppendException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class BuildExceptionTest extends TestCase
+{
+    #[Test]
+    public function biscuitBuildExceptionExtendsBuildExceptionAndBiscuitException(): void
+    {
+        static::assertTrue(is_subclass_of(BiscuitBuildException::class, BuildException::class));
+        static::assertTrue(is_subclass_of(BiscuitBuildException::class, BiscuitException::class));
+    }
+
+    #[Test]
+    public function blockAppendExceptionExtendsBuildException(): void
+    {
+        static::assertTrue(is_subclass_of(BlockAppendException::class, BuildException::class));
+        static::assertTrue(is_subclass_of(BlockAppendException::class, BiscuitException::class));
+    }
+
+    #[Test]
+    public function authorizerBuildExceptionExtendsBuildException(): void
+    {
+        static::assertTrue(is_subclass_of(AuthorizerBuildException::class, BuildException::class));
+        static::assertTrue(is_subclass_of(AuthorizerBuildException::class, BiscuitException::class));
+    }
+
+    #[Test]
+    public function thirdPartyBlockAppendExceptionExtendsBuildException(): void
+    {
+        static::assertTrue(is_subclass_of(ThirdPartyBlockAppendException::class, BuildException::class));
+        static::assertTrue(is_subclass_of(ThirdPartyBlockAppendException::class, BiscuitException::class));
+    }
+}

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Biscuit\Tests;
 
 use Biscuit\Auth\Check;
-use Biscuit\Exception\InvalidCheck;
+use Biscuit\Exception\CheckException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class CheckTest extends TestCase
@@ -18,12 +19,11 @@ class CheckTest extends TestCase
         static::assertSame('check if resource("uuid"), operation("read") or admin("authority")', (string) $check);
     }
 
-    public function testExcpetionWhenBadCheck(): void
+    #[Test]
+    public function badCheckThrowsCheckException(): void
     {
-        $this->expectException(InvalidCheck::class);
-        $this->expectExceptionMessage(
-            'error generating Datalog: datalog parsing error: ParseErrors { errors: [ParseError { input: "wrong", message: None }] }',
-        );
+        $this->expectException(CheckException::class);
+        $this->expectExceptionMessage('datalog parsing error');
 
         new Check('wrong');
     }

--- a/tests/DatalogExceptionTest.php
+++ b/tests/DatalogExceptionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Biscuit\Tests;
+
+use Biscuit\Auth\BiscuitBuilder;
+use Biscuit\Auth\Fact;
+use Biscuit\Auth\KeyPair;
+use Biscuit\Auth\ParseError;
+use Biscuit\Auth\Rule;
+use Biscuit\Exception\DatalogException;
+use Biscuit\Exception\FactException;
+use Biscuit\Exception\RuleException;
+use Biscuit\Exception\ScopeException;
+use Biscuit\Exception\TermException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class DatalogExceptionTest extends TestCase
+{
+    #[Test]
+    public function parseFailurePopulatesParseErrorsAndLeavesParameterAccessorsNull(): void
+    {
+        try {
+            new Fact('wrong');
+            static::fail('expected FactException');
+        } catch (FactException $e) {
+            static::assertInstanceOf(DatalogException::class, $e);
+
+            $parseErrors = $e->getParseErrors();
+            static::assertIsArray($parseErrors);
+            static::assertNotEmpty($parseErrors);
+            static::assertContainsOnlyInstancesOf(ParseError::class, $parseErrors);
+
+            static::assertNull($e->getMissingParameters());
+            static::assertNull($e->getUnusedParameters());
+        }
+    }
+
+    #[Test]
+    public function unusedParameterPopulatesUnusedParametersAndLeavesOthersEmpty(): void
+    {
+        try {
+            new Rule('foo({x}) <- bar({y})', ['z' => 1]);
+            static::fail('expected TermException');
+        } catch (TermException $e) {
+            static::assertInstanceOf(DatalogException::class, $e);
+
+            static::assertNull($e->getParseErrors());
+
+            $missing = $e->getMissingParameters();
+            $unused = $e->getUnusedParameters();
+            static::assertIsArray($missing);
+            static::assertIsArray($unused);
+            static::assertSame([], $missing);
+            static::assertSame(['z'], $unused);
+        }
+    }
+
+    #[Test]
+    public function missingParameterPopulatesMissingParametersAtBuilderTime(): void
+    {
+        $rule = new Rule('foo({x}) <- bar({y})');
+
+        try {
+            $builder = new BiscuitBuilder();
+            $builder->addRule($rule);
+            static::fail('expected RuleException');
+        } catch (RuleException $e) {
+            static::assertInstanceOf(DatalogException::class, $e);
+
+            static::assertNull($e->getParseErrors());
+
+            $missing = $e->getMissingParameters();
+            $unused = $e->getUnusedParameters();
+            static::assertIsArray($missing);
+            static::assertIsArray($unused);
+            static::assertContains('x', $missing);
+            static::assertContains('y', $missing);
+            static::assertSame([], $unused);
+        }
+    }
+
+    #[Test]
+    public function termFailureLeavesAllAccessorsNull(): void
+    {
+        try {
+            $fact = new Fact('user({id})');
+            $fact->set('id', null);
+            static::fail('expected TermException');
+        } catch (TermException $e) {
+            static::assertInstanceOf(DatalogException::class, $e);
+
+            static::assertNull($e->getParseErrors());
+            static::assertNull($e->getMissingParameters());
+            static::assertNull($e->getUnusedParameters());
+        }
+    }
+
+    #[Test]
+    public function unusedScopeParameterThrowsScopeException(): void
+    {
+        $keyPair = new KeyPair();
+        $key = $keyPair->getPublicKey();
+
+        try {
+            new Rule('right({id}) <- user({id})', null, ['nonexistent' => $key]);
+            static::fail('expected ScopeException');
+        } catch (ScopeException $e) {
+            static::assertInstanceOf(DatalogException::class, $e);
+        }
+    }
+
+    #[Test]
+    public function parseErrorAccessorsExposeInputAndMessage(): void
+    {
+        try {
+            new Fact('wrong');
+            static::fail('expected FactException');
+        } catch (FactException $e) {
+            $parseErrors = $e->getParseErrors();
+            static::assertIsArray($parseErrors);
+            static::assertNotEmpty($parseErrors);
+
+            $first = $parseErrors[0];
+            static::assertInstanceOf(ParseError::class, $first);
+            static::assertIsString($first->getInput());
+
+            $message = $first->getMessage();
+            static::assertTrue($message === null || is_string($message));
+        }
+    }
+}

--- a/tests/FactTest.php
+++ b/tests/FactTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Biscuit\Tests;
 
 use Biscuit\Auth\Fact;
-use Biscuit\Exception\InvalidFact;
+use Biscuit\Exception\FactException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class FactTest extends TestCase
@@ -30,12 +31,11 @@ class FactTest extends TestCase
         static::assertSame('user("bob")', (string) $fact);
     }
 
-    public function testExcpetionWhenBadFact(): void
+    #[Test]
+    public function badFactThrowsFactException(): void
     {
-        $this->expectException(InvalidFact::class);
-        $this->expectExceptionMessage(
-            'error generating Datalog: datalog parsing error: ParseErrors { errors: [ParseError { input: "", message: None }] }',
-        );
+        $this->expectException(FactException::class);
+        $this->expectExceptionMessage('datalog parsing error');
 
         new Fact('wrong');
     }

--- a/tests/FormatExceptionTest.php
+++ b/tests/FormatExceptionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Biscuit\Tests;
+
+use Biscuit\Auth\Authorizer;
+use Biscuit\Auth\Biscuit;
+use Biscuit\Auth\BiscuitBuilder;
+use Biscuit\Auth\KeyPair;
+use Biscuit\Auth\UnverifiedBiscuit;
+use Biscuit\Exception\Base64Exception;
+use Biscuit\Exception\BiscuitException;
+use Biscuit\Exception\BytesException;
+use Biscuit\Exception\FormatException;
+use Biscuit\Exception\SignatureException;
+use Biscuit\Exception\SnapshotException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class FormatExceptionTest extends TestCase
+{
+    #[Test]
+    public function base64ExceptionExtendsFormatExceptionAndBiscuitException(): void
+    {
+        static::assertTrue(is_subclass_of(Base64Exception::class, FormatException::class));
+        static::assertTrue(is_subclass_of(Base64Exception::class, BiscuitException::class));
+    }
+
+    #[Test]
+    public function invalidBase64TokenThrowsBase64Exception(): void
+    {
+        $keyPair = new KeyPair();
+        $rootKey = $keyPair->getPublicKey();
+        $this->expectException(Base64Exception::class);
+
+        Biscuit::fromBase64('this-is-not-valid-base64-token-data!!', $rootKey);
+    }
+
+    #[Test]
+    public function bytesExceptionExtendsFormatException(): void
+    {
+        static::assertTrue(is_subclass_of(BytesException::class, FormatException::class));
+    }
+
+    #[Test]
+    public function invalidByteSequenceThrowsBytesException(): void
+    {
+        $keyPair = new KeyPair();
+        $rootKey = $keyPair->getPublicKey();
+        $this->expectException(BytesException::class);
+
+        Biscuit::fromBytes('garbage-bytes', $rootKey);
+    }
+
+    #[Test]
+    public function signatureExceptionExtendsFormatException(): void
+    {
+        static::assertTrue(is_subclass_of(SignatureException::class, FormatException::class));
+    }
+
+    #[Test]
+    public function verifyingWithWrongRootKeyThrowsSignatureException(): void
+    {
+        $rootA = new KeyPair();
+        $rootB = new KeyPair();
+
+        $builder = new BiscuitBuilder('user("alice");');
+        $biscuit = $builder->build($rootA->getPrivateKey());
+        $token = $biscuit->toBase64();
+
+        $unverified = UnverifiedBiscuit::fromBase64($token);
+
+        $this->expectException(SignatureException::class);
+        $unverified->verify($rootB->getPublicKey());
+    }
+
+    #[Test]
+    public function snapshotExceptionExtendsFormatException(): void
+    {
+        static::assertTrue(is_subclass_of(SnapshotException::class, FormatException::class));
+    }
+
+    #[Test]
+    public function invalidBase64SnapshotThrowsSnapshotException(): void
+    {
+        $this->expectException(SnapshotException::class);
+
+        Authorizer::fromBase64Snapshot('not-a-real-snapshot-payload');
+    }
+}

--- a/tests/KeyExceptionTest.php
+++ b/tests/KeyExceptionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Biscuit\Tests;
+
+use Biscuit\Auth\PrivateKey;
+use Biscuit\Auth\PublicKey;
+use Biscuit\Exception\BiscuitException;
+use Biscuit\Exception\KeyException;
+use Biscuit\Exception\PrivateKeyException;
+use Biscuit\Exception\PublicKeyException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class KeyExceptionTest extends TestCase
+{
+    #[Test]
+    public function publicKeyExceptionExtendsKeyExceptionAndBiscuitException(): void
+    {
+        static::assertTrue(is_subclass_of(PublicKeyException::class, KeyException::class));
+        static::assertTrue(is_subclass_of(PublicKeyException::class, BiscuitException::class));
+    }
+
+    #[Test]
+    public function publicKeyParseFailureThrowsPublicKeyException(): void
+    {
+        $this->expectException(PublicKeyException::class);
+
+        new PublicKey('not-a-valid-public-key');
+    }
+
+    #[Test]
+    public function privateKeyExceptionExtendsKeyExceptionAndBiscuitException(): void
+    {
+        static::assertTrue(is_subclass_of(PrivateKeyException::class, KeyException::class));
+        static::assertTrue(is_subclass_of(PrivateKeyException::class, BiscuitException::class));
+    }
+
+    #[Test]
+    public function privateKeyParseFailureThrowsPrivateKeyException(): void
+    {
+        $this->expectException(PrivateKeyException::class);
+
+        new PrivateKey('not-a-valid-private-key');
+    }
+}

--- a/tests/KeyPairTest.php
+++ b/tests/KeyPairTest.php
@@ -8,6 +8,7 @@ use Biscuit\Auth\Algorithm;
 use Biscuit\Auth\KeyPair;
 use Biscuit\Auth\PrivateKey;
 use Biscuit\Auth\PublicKey;
+use Biscuit\Exception\PrivateKeyException;
 use PHPUnit\Framework\TestCase;
 
 class KeyPairTest extends TestCase
@@ -79,7 +80,7 @@ class KeyPairTest extends TestCase
 
     public function testInvalidPrivateKeyException(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(PrivateKeyException::class);
 
         new PrivateKey('invalid-key-format');
     }

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Biscuit\Tests;
 
 use Biscuit\Auth\Policy;
-use Biscuit\Exception\InvalidPolicy;
+use Biscuit\Exception\PolicyException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class PolicyTest extends TestCase
@@ -18,12 +19,11 @@ class PolicyTest extends TestCase
         static::assertSame('allow if resource(true)', (string) $policy);
     }
 
-    public function testExcpetionWhenBadPolicy(): void
+    #[Test]
+    public function badPolicyThrowsPolicyException(): void
     {
-        $this->expectException(InvalidPolicy::class);
-        $this->expectExceptionMessage(
-            'error generating Datalog: datalog parsing error: ParseErrors { errors: [ParseError { input: "wrong", message: None }] }',
-        );
+        $this->expectException(PolicyException::class);
+        $this->expectExceptionMessage('datalog parsing error');
 
         new Policy('wrong');
     }

--- a/tests/RbacExampleTest.php
+++ b/tests/RbacExampleTest.php
@@ -7,8 +7,10 @@ namespace Biscuit\Tests;
 use Biscuit\Auth\AuthorizerBuilder;
 use Biscuit\Auth\Biscuit;
 use Biscuit\Auth\BiscuitBuilder;
+use Biscuit\Auth\FailedCheck;
 use Biscuit\Auth\KeyPair;
-use Biscuit\Exception\AuthorizerError;
+use Biscuit\Auth\MatchedPolicy;
+use Biscuit\Exception\AuthorizationException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -131,7 +133,7 @@ class RbacExampleTest extends TestCase
         $authorizer = $authBuilder->build($token);
 
         // Authorization should fail because writer doesn't have critical priority role
-        $this->expectException(AuthorizerError::class);
+        $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('authorization failed');
         $authorizer->authorize();
     }
@@ -194,8 +196,56 @@ class RbacExampleTest extends TestCase
         ');
         $authBuilder2->addCode('operation("api:delete"); resource("normal");');
 
-        $this->expectException(AuthorizerError::class);
+        $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('authorization failed');
         $authBuilder2->build($token)->authorize();
+    }
+
+    public function testAuthorizationExceptionCarriesStructuredPayload(): void
+    {
+        $rootKp = new KeyPair();
+        $builder = new BiscuitBuilder();
+        $builder->addCode('user("alice")');
+        $token = $builder->build($rootKp->getPrivateKey());
+
+        $authBuilder = new AuthorizerBuilder('check if admin($u); deny if true;');
+        $authorizer = $authBuilder->build($token);
+
+        try {
+            $authorizer->authorize();
+            static::fail('expected AuthorizationException');
+        } catch (AuthorizationException $e) {
+            static::assertStringContainsString('authorization failed', $e->getMessage());
+
+            $matched = $e->getMatchedPolicy();
+            static::assertInstanceOf(MatchedPolicy::class, $matched);
+            static::assertSame('deny', $matched->getKind());
+            static::assertSame(0, $matched->getPolicyId());
+            static::assertStringContainsString('deny if true', (string) $matched->getCode());
+
+            $checks = $e->getFailedChecks();
+            static::assertIsArray($checks);
+            static::assertCount(1, $checks);
+            static::assertInstanceOf(FailedCheck::class, $checks[0]);
+            static::assertSame('authorizer', $checks[0]->getOrigin());
+            static::assertNull($checks[0]->getBlockId());
+            static::assertStringContainsString('admin($u)', $checks[0]->getRule());
+        }
+    }
+
+    public function testAuthorizeSuccessReturnsMatchedPolicy(): void
+    {
+        $rootKp = new KeyPair();
+        $builder = new BiscuitBuilder();
+        $builder->addCode('user("alice")');
+        $token = $builder->build($rootKp->getPrivateKey());
+
+        $authBuilder = new AuthorizerBuilder('allow if user("alice")');
+        $matched = $authBuilder->build($token)->authorize();
+
+        static::assertInstanceOf(MatchedPolicy::class, $matched);
+        static::assertSame('allow', $matched->getKind());
+        static::assertSame(0, $matched->getPolicyId());
+        static::assertStringContainsString('allow if user("alice")', (string) $matched->getCode());
     }
 }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Biscuit\Tests;
 
 use Biscuit\Auth\Rule;
-use Biscuit\Exception\InvalidRule;
+use Biscuit\Exception\RuleException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class RuleTest extends TestCase
@@ -18,12 +19,11 @@ class RuleTest extends TestCase
         static::assertSame('right(15, "read") <- resource(15), operation("read")', (string) $rule);
     }
 
-    public function testExcpetionWhenBadRule(): void
+    #[Test]
+    public function badRuleThrowsRuleException(): void
     {
-        $this->expectException(InvalidRule::class);
-        $this->expectExceptionMessage(
-            'error generating Datalog: datalog parsing error: ParseErrors { errors: [ParseError { input: "", message: None }] }',
-        );
+        $this->expectException(RuleException::class);
+        $this->expectExceptionMessage('datalog parsing error');
 
         new Rule('wrong');
     }


### PR DESCRIPTION
Address #14

Replaces the flat `Invalid*` classes with a deep typed hierarchy rooted at `Biscuit\Exception\BiscuitException`. Every failure shape has its own concrete subclass, so callers use PHP multi-catch instead of branching on a message string or an int code. `AuthorizationException` and every `DatalogException` subclass carry structured payloads (matched policy + failed checks; parse errors + missing/unused parameters).

## Hierarchy

```mermaid
graph TD
    Ex["\Exception"] --> Biscuit[BiscuitException]
    Biscuit --> Key[KeyException]
    Biscuit --> Datalog[DatalogException]
    Biscuit --> Format[FormatException]
    Biscuit --> Build[BuildException]
    Biscuit --> Authz[AuthorizationException]
    Biscuit --> Third[ThirdPartyException]
    Biscuit --> Builder[BuilderStateException]

    Key --> PublicKeyException
    Key --> PrivateKeyException

    Datalog --> FactException
    Datalog --> RuleException
    Datalog --> CheckException
    Datalog --> PolicyException
    Datalog --> TermException
    Datalog --> ScopeException

    Format --> Base64Exception
    Format --> BytesException
    Format --> SignatureException
    Format --> SnapshotException

    Build --> BiscuitBuildException
    Build --> BlockAppendException
    Build --> AuthorizerBuildException
    Build --> ThirdPartyBlockAppendException
```

All exceptions live in `Biscuit\Exception\`. Catch the leaf for precise handling or the parent (`KeyException`, `DatalogException`, `FormatException`, `BuildException`, or `BiscuitException` ) to catch a category.

Breaking change. Full migration guide in `UPGRADING.md`.
