### PR TITLE
ci: add PHP debug build job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,3 +64,43 @@ jobs:
 
       - name: "Run PHPUnit"
         run: php -dextension=./target/release/libbiscuit_php.so vendor/bin/phpunit
+
+  tests-debug:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    name: Build extension and run tests (PHP debug)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-debug-
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: "Install PHP (debug build)"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.5"
+          coverage: "none"
+          ini-values: "memory_limit=-1"
+          extensions: mbstring
+          tools: composer:v2.9.7
+        env:
+          debug: true
+
+      - name: Build
+        run: cargo build --release --all-features
+
+      - name: "Install dependencies (Composer)"
+        uses: "ramsey/composer-install@v3"
+
+      - name: "Run PHPUnit"
+        run: php -dextension=./target/release/libbiscuit_php.so vendor/bin/phpunit


### PR DESCRIPTION
Adds a `tests-debug` job that runs PHPUnit against a PHP debug build. The debug build enables Zend's refcount invariants and the leak detector at shutdown, which catches FFI refcount mistakes that release builds silently let through.

Spotted while tracing the `DatalogException::getMessage` leak: the release matrix passed, the bug only surfaced because I happened to be on a local PHP 8.5-dev debug build. With this job we would have caught it in CI.

Runs on PHP 8.5 with `continue-on-error: true` for the initial rollout so unrelated bleeding-edge asserts do not block PRs. Flip to false once we trust the signal.
